### PR TITLE
Remediate audit findings in API

### DIFF
--- a/AUDIT_REPORT_2026-08-06.md
+++ b/AUDIT_REPORT_2026-08-06.md
@@ -1,0 +1,348 @@
+# Báo cáo audit Codohue - 2026-08-06
+
+## 1. Phạm vi và kết luận
+
+Đợt audit này tập trung vào các luồng có rủi ro cao của Codohue:
+
+- cách ly multi-tenant và xác thực;
+- recommendation cache và tính đúng đắn của kết quả;
+- catalog auto-embedding và vòng đời re-embed;
+- batch compute, reset và xóa namespace;
+- ingest validation và tính toàn vẹn dữ liệu;
+- giới hạn tài nguyên HTTP;
+- tài liệu, SDK và công cụ vận hành.
+
+Không phát hiện lỗi biên dịch hay test failure trên các luồng thông thường. Tuy
+nhiên, có **4 vấn đề mức High**, **5 vấn đề mức Medium** và một nhóm sai lệch
+giữa contract với tài liệu. Các lỗi High cần được xử lý trước khi coi hệ thống
+đủ an toàn để vận hành production.
+
+## 2. Tóm tắt mức độ ưu tiên
+
+| ID | Mức độ | Vấn đề | Ảnh hưởng chính |
+|---|---|---|---|
+| F-01 | High | Recommendation cache có thể va chạm giữa namespace | Lộ dữ liệu recommendation chéo tenant |
+| F-02 | High | Re-embed có thể báo thành công khi item vẫn pending | Trạng thái vận hành sai, rebuild Qdrant không hoàn tất |
+| F-03 | High | Xóa namespace mất khả năng retry sau lỗi partial | Dữ liệu Redis/Qdrant bị bỏ lại vĩnh viễn |
+| F-04 | High | Reset app không khóa compute đang chạy | Dữ liệu/collection bị tái tạo sau reset |
+| F-05 | Medium | Ingest fallback khi đọc config lỗi | Event sai weight, chấp nhận namespace ma |
+| F-06 | Medium | Dense phase lỗi nhưng batch vẫn success | Dashboard báo xanh sai sự thật |
+| F-07 | Medium | Xóa catalog item nuốt lỗi Qdrant | Dense vector mồ côi vẫn được recommend |
+| F-08 | Medium | Login limiter có thể khóa toàn bộ admin | Từ chối dịch vụ trên admin plane |
+| F-09 | Medium | JSON request body không có hard limit | Cạn bộ nhớ/CPU |
+| F-10 | Low | README, SDK docs và eval script dùng contract cũ | Quickstart và tooling chạy sai |
+
+### Trạng thái remediation
+
+Các finding dưới đây đã được xử lý trên nhánh `fix/audit-remediation`:
+
+| ID | Trạng thái | Thay đổi chính |
+|---|---|---|
+| F-01 | Đã xử lý | Cache key dùng Base64URL cho từng thành phần và cache hit xác minh lại namespace/subject |
+| F-02 | Đã xử lý | Item được re-drive bị xóa version cũ; watcher dùng target version đã lưu trên batch run |
+| F-03 | Đã xử lý | Delete vẫn chạy cleanup khi config đã mất, cho phép retry sau partial failure |
+| F-04 | Đã xử lý | Compute/delete giữ shared maintenance lock; reset giữ exclusive lock đến khi cleanup hoàn tất |
+| F-05 | Đã xử lý | Lỗi config được trả về để retry; namespace không tồn tại bị reject thay vì dùng default weight |
+| F-06 | Đã xử lý | Dense phase lỗi làm aggregate run thất bại nhưng không ngăn trending phase chạy |
+| F-07 | Đã xử lý | Qdrant được xóa trước PostgreSQL; lỗi external cleanup được trả về để retry |
+| F-08 | Đã xử lý | Credential đúng bỏ qua failed-attempt bucket, tránh lockout qua IP proxy dùng chung |
+| F-09 | Đã xử lý | Strict JSON decoder có hard cap 8 MiB và kiểm tra trailing payload đầy đủ |
+| F-10 | Đã xử lý | README, eval script và Redis Streams SDK docs đã dùng contract hiện hành |
+
+## 3. Findings chi tiết
+
+### F-01 - Recommendation cache có thể va chạm giữa namespace
+
+**Mức độ:** High
+**Thành phần:** `internal/recommend`, `internal/nsconfig`
+
+Cache key được ghép trực tiếp bằng dấu `:`:
+
+```text
+rec:{namespace}:{subject_id}:limit={limit}:offset={offset}
+```
+
+Trong khi đó, server không validate bộ ký tự của namespace. Ví dụ hai request:
+
+```text
+namespace="a",   subject_id="b:c"
+namespace="a:b", subject_id="c"
+```
+
+đều tạo key:
+
+```text
+rec:a:b:c:limit=20:offset=0
+```
+
+Cache hit được deserialize và trả thẳng, không đối chiếu lại `Namespace` và
+`SubjectID` trong response. Tenant thứ hai vì vậy có thể nhận recommendation đã
+cache của tenant thứ nhất.
+
+**Vị trí:**
+
+- [`internal/recommend/service.go:291`](internal/recommend/service.go#L291)
+- [`internal/recommend/service.go:1453`](internal/recommend/service.go#L1453)
+- [`internal/nsconfig/service.go:72`](internal/nsconfig/service.go#L72)
+
+**Khuyến nghị:**
+
+1. Validate namespace theo một slug format rõ ràng, ví dụ `^[a-z0-9][a-z0-9_-]{0,62}$`.
+2. Dùng cache key có encoding không mơ hồ, ví dụ hash `(namespace, subject_id)`
+   hoặc length-prefix từng thành phần.
+3. Khi đọc cache, xác minh response namespace/subject khớp request trước khi trả.
+4. Thêm test với namespace và subject ID chứa dấu `:`.
+
+### F-02 - Re-embed có thể đóng run quá sớm
+
+**Mức độ:** High
+**Thành phần:** `internal/admin`, `internal/embedder`
+
+Khi operator gọi re-embed với `only_state=all`, `embedded` hoặc `failed`, query
+reset item về `pending` nhưng giữ nguyên `strategy_version`. Completion watcher
+chỉ đếm `pending|in_flight|failed` nếu version của item khác version hiện tại.
+
+Với một same-version rebuild, watcher có thể thấy `stale=0` ngay sau reset và
+đánh dấu batch run thành công trước khi worker xử lý bất kỳ item nào. Đây chính
+là đường rebuild sau khi mất dữ liệu Qdrant, nên false-success có thể để
+collection rỗng trong khi dashboard báo xanh.
+
+Ngoài ra, production watcher join với `namespace_configs` hiện tại thay vì dùng
+`target_strategy_id` và `target_strategy_version` đã đóng băng trên batch run.
+Nếu config đổi giữa run, watcher sẽ theo dõi sai target.
+
+**Vị trí:**
+
+- [`internal/admin/catalog_ops_repository.go:188`](internal/admin/catalog_ops_repository.go#L188)
+- [`internal/admin/catalog_ops_repository.go:200`](internal/admin/catalog_ops_repository.go#L200)
+- [`internal/embedder/reembed_watcher.go:200`](internal/embedder/reembed_watcher.go#L200)
+- [`internal/embedder/reembed_watcher.go:221`](internal/embedder/reembed_watcher.go#L221)
+
+**Khuyến nghị:**
+
+1. Cho watcher đọc target version từ chính row trong `batch_run_logs`.
+2. Theo dõi tập item thuộc run, không suy diễn completion chỉ từ version hiện tại.
+3. Tối thiểu, mọi item `pending|in_flight|failed` được reset bởi run phải được
+   tính là outstanding bất kể version.
+4. Thêm E2E cho `only_state=all` với target version không đổi và Qdrant collection rỗng.
+
+### F-03 - Xóa namespace mất khả năng retry sau partial failure
+
+**Mức độ:** High
+**Thành phần:** `internal/admin`
+
+`clearNamespaceEverywhere` xóa PostgreSQL trước, bao gồm `namespace_configs`,
+sau đó mới xóa Redis và Qdrant. Nếu Redis hoặc Qdrant lỗi, endpoint trả 500 nhưng
+namespace config đã biến mất. Lần retry sau dừng ngay ở pre-check và trả 404,
+không tiếp tục dọn dữ liệu còn sót.
+
+**Kịch bản:**
+
+1. Operator gọi xóa namespace.
+2. PostgreSQL transaction commit thành công.
+3. Qdrant tạm thời unavailable.
+4. Endpoint trả 500; collection vẫn còn.
+5. Operator retry; endpoint trả 404 vì config đã bị xóa.
+
+**Vị trí:**
+
+- [`internal/admin/service.go:880`](internal/admin/service.go#L880)
+- [`internal/admin/service.go:1018`](internal/admin/service.go#L1018)
+- [`internal/admin/service.go:1059`](internal/admin/service.go#L1059)
+
+**Khuyến nghị:**
+
+- Dùng tombstone/deletion state và quy trình cleanup có thể retry; hoặc
+- cho phép delete endpoint cleanup Redis/Qdrant kể cả khi config không còn; và
+- ghi durable cleanup job/outbox trước khi xóa owner row trong PostgreSQL.
+
+### F-04 - Reset app không đồng bộ với compute đang chạy
+
+**Mức độ:** High
+**Thành phần:** `internal/admin`, `internal/compute`
+
+`ResetApp` truncate các bảng và xóa Redis/Qdrant mà không lấy compute advisory
+lock. Cron hoặc manual run đang chạy có thể tiếp tục upsert vector/collection sau
+khi reset hoàn tất. Batch row của run cũng đã bị truncate, nên finalize sau đó
+không còn nơi để ghi trạng thái.
+
+**Vị trí:**
+
+- [`internal/admin/service.go:915`](internal/admin/service.go#L915)
+- [`internal/admin/service.go:927`](internal/admin/service.go#L927)
+- [`internal/compute/job.go:219`](internal/compute/job.go#L219)
+
+**Khuyến nghị:** thêm global maintenance advisory lock mà mọi compute run phải
+giữ shared/exclusive theo quy ước, hoặc lấy toàn bộ namespace locks trước reset
+và chỉ truncate sau khi các run đã drain.
+
+### F-05 - Ingest nuốt lỗi namespace config
+
+**Mức độ:** Medium
+**Thành phần:** `internal/ingest`
+
+`resolveWeight` fallback sang default action weights khi:
+
+- query namespace config gặp lỗi hạ tầng; hoặc
+- namespace không tồn tại.
+
+Hệ quả là event có thể được ghi với weight sai so với config của tenant. Redis
+Streams producer cũng có thể tạo event cho namespace ma vì bảng `events` không
+có foreign key tới `namespace_configs`. Unit test hiện đang đóng đinh hành vi
+fallback khi DB lỗi.
+
+**Vị trí:**
+
+- [`internal/ingest/service.go:110`](internal/ingest/service.go#L110)
+- [`internal/ingest/service_test.go:123`](internal/ingest/service_test.go#L123)
+- [`migrations/001_initial.up.sql:10`](migrations/001_initial.up.sql#L10)
+
+**Khuyến nghị:** phân biệt rõ ba trạng thái `config found`, `namespace missing`
+và `infrastructure error`. Chỉ dùng default weights khi namespace tồn tại nhưng
+không override action đó; hai trường hợp còn lại phải reject/retry.
+
+### F-06 - Dense phase lỗi nhưng batch vẫn success
+
+**Mức độ:** Medium
+**Thành phần:** `internal/compute`, admin dashboard
+
+Phase 2 failure được ghi vào phase result nhưng không fold vào `runErr`. Nếu
+phase 1 và phase 3 thành công, `batch_run_logs.success` vẫn là `true`. Điều này
+mâu thuẫn với tài liệu nói rằng all-green nghĩa là mọi phase đã chạy đều thành công.
+
+**Vị trí:**
+
+- [`internal/compute/job.go:334`](internal/compute/job.go#L334)
+- [`internal/compute/job.go:369`](internal/compute/job.go#L369)
+- [`ARCHITECTURE.md:205`](ARCHITECTURE.md#L205)
+
+**Khuyến nghị:** vẫn cho phase 3 tiếp tục sau phase 2 failure, nhưng aggregate
+run phải `success=false`; hoặc thêm trạng thái `degraded` riêng và hiển thị rõ
+trên API/UI.
+
+### F-07 - Xóa catalog item để lại vector mồ côi
+
+**Mức độ:** Medium
+**Thành phần:** `internal/admin`
+
+Catalog row bị xóa khỏi PostgreSQL trước khi numeric ID được lookup và Qdrant
+point được xóa. Lỗi lookup/Qdrant chỉ được log; endpoint vẫn trả 204. Khi retry,
+row không còn nên code return ngay và không thể phục hồi `object_id` để cleanup.
+
+**Vị trí:**
+
+- [`internal/admin/catalog_ops_service.go:355`](internal/admin/catalog_ops_service.go#L355)
+- [`internal/admin/catalog_ops_service.go:360`](internal/admin/catalog_ops_service.go#L360)
+- [`internal/admin/catalog_ops_service.go:370`](internal/admin/catalog_ops_service.go#L370)
+- [`internal/admin/catalog_ops_service.go:382`](internal/admin/catalog_ops_service.go#L382)
+
+**Khuyến nghị:** resolve numeric ID trước, xóa Qdrant trước khi xóa row, hoặc ghi
+durable cleanup task. Không trả success nếu cleanup bắt buộc chưa thành công.
+
+### F-08 - Login rate limiter có thể khóa toàn bộ admin plane
+
+**Mức độ:** Medium
+**Thành phần:** `internal/admin`
+
+Limiter được kiểm tra trước khi credential được validate. Sau khi bucket cạn,
+credential đúng cũng bị trả 429. `clientIP` chỉ dùng `RemoteAddr`; khi chạy sau
+reverse proxy, mọi operator thường cùng chia sẻ IP của proxy. Năm lần login sai
+có thể khóa tất cả operator cho tới khi bucket refill.
+
+**Vị trí:**
+
+- [`internal/admin/handler.go:104`](internal/admin/handler.go#L104)
+- [`internal/admin/session.go:189`](internal/admin/session.go#L189)
+- [`internal/admin/session.go:233`](internal/admin/session.go#L233)
+
+**Khuyến nghị:** chỉ tin forwarded headers từ danh sách trusted proxies, thêm
+global + per-principal limiter, và cho credential đúng vượt qua failed-attempt
+bucket hoặc dùng cooldown ngắn có bounded exponential delay.
+
+### F-09 - JSON request body không có giới hạn kích thước
+
+**Mức độ:** Medium
+**Thành phần:** HTTP data plane và admin plane
+
+`DecodeStrict` đọc JSON trực tiếp từ body mà không qua `http.MaxBytesReader`.
+Catalog content limit chỉ được kiểm tra sau khi string đã được decode và cấp
+phát. Embedding vector cũng có thể làm server cấp phát một slice rất lớn trước
+khi dimension validation chạy.
+
+**Vị trí:**
+
+- [`internal/core/httpapi/httpapi.go:26`](internal/core/httpapi/httpapi.go#L26)
+- [`internal/catalog/handler.go:57`](internal/catalog/handler.go#L57)
+- [`internal/catalog/service.go:112`](internal/catalog/service.go#L112)
+- [`internal/recommend/handler.go:211`](internal/recommend/handler.go#L211)
+
+**Khuyến nghị:** đặt route-specific body caps trước decode. Catalog batch cap
+cần tính theo `max_items * max_content_bytes` cộng metadata overhead; embedding
+cap theo configured dimension cộng một margin nhỏ.
+
+### F-10 - Contract và tài liệu bị sai lệch
+
+**Mức độ:** Low
+**Thành phần:** README, SDK docs, evaluation tooling
+
+Các ví dụ vẫn dùng contract trước dense-source unification:
+
+- README gửi `dense_strategy`, trong khi strict decoder chỉ nhận `dense_source`;
+- README vẫn mô tả `catalog_enabled=true`;
+- `scripts/eval.py` gửi `dense_strategy`, làm `make eval` fail với HTTP 400;
+- ví dụ Redis dùng `timestamp` thay cho `occurred_at`, nên timestamp bị bỏ qua
+  và ingest thay bằng thời gian hiện tại;
+- Redis SDK README khởi tạo field `Timestamp`, field này không tồn tại trên
+  `codohuetypes.EventPayload`.
+
+**Vị trí:**
+
+- [`README.md:111`](README.md#L111)
+- [`README.md:129`](README.md#L129)
+- [`README.md:201`](README.md#L201)
+- [`scripts/eval.py:537`](scripts/eval.py#L537)
+- [`scripts/eval.py:608`](scripts/eval.py#L608)
+- [`sdk/go/redistream/README.md:42`](sdk/go/redistream/README.md#L42)
+
+## 4. Khoảng trống của test suite
+
+Test suite hiện tại chưa bao phủ các fault/race scenario sau:
+
+- cache key collision với namespace/subject chứa delimiter;
+- re-embed `only_state=all` ở cùng strategy version;
+- strategy config đổi trong khi re-embed run đang mở;
+- Redis/Qdrant failure sau khi PostgreSQL delete đã commit;
+- reset trong lúc cron/manual compute đang upsert;
+- namespace config lookup fail trong ingest;
+- phase 2 fail nhưng phase 3 thành công;
+- login brute-force khi admin nằm sau reverse proxy;
+- oversized authenticated JSON body.
+
+## 5. Kết quả xác minh
+
+Tại thời điểm audit:
+
+| Check | Kết quả |
+|---|---|
+| `make test` | Pass |
+| `make test-race` | Pass |
+| `make test-e2e` | Pass |
+| `make lint` | Pass, 0 issues |
+| `make web-admin-lint` | Pass |
+| `make web-admin-test` | Pass |
+| `make compose-check` | Pass |
+| Migration version | 23 |
+| Git working tree trước report | Clean |
+
+E2E pass xác nhận happy paths hoạt động, nhưng không phủ định các findings trên
+vì chúng nằm ở fault-injection, same-version rebuild, cross-tenant key encoding
+và concurrent lifecycle paths.
+
+## 6. Thứ tự remediation đề xuất
+
+1. **Tenant isolation:** F-01.
+2. **Lifecycle truthfulness:** F-02, F-04, F-06.
+3. **Retryable deletion:** F-03, F-07.
+4. **Data integrity:** F-05.
+5. **Security/resource hardening:** F-08, F-09.
+6. **Contract cleanup:** F-10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,55 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
 
 ## Unreleased
 
-Nothing yet.
+Planned server release: `v0.9.0`. Planned Go module maintenance release:
+`v0.5.1` for `pkg/codohuetypes`, `sdk/go`, and `sdk/go/redistream`.
+
+### Breaking
+
+- **Event ingest now rejects unknown namespaces.** Events are no longer stored
+  with default action weights when the namespace is missing. Redis Stream
+  entries targeting a missing namespace are treated as permanently invalid,
+  acknowledged, and dropped.
+- **Catalog item deletion now reports Qdrant cleanup failures.** The endpoint
+  returns a server error and retains the PostgreSQL row so callers can retry,
+  instead of returning `204` after a best-effort external cleanup.
+- **JSON request bodies have an 8 MiB hard limit.** Oversized requests are
+  rejected before business validation. Admin request decoders also reject
+  unknown fields and trailing JSON data consistently.
+- **Dense phase failures now fail the aggregate batch run.** The independent
+  trending phase still runs, but `batch_run_logs.success` is `false` when the
+  dense phase fails.
+
+### Fixed
+
+- Prevent cross-namespace recommendation cache collisions by encoding each
+  cache-key component independently and validating cached response identity.
+- Prevent same-version catalog re-embed runs from completing before reset
+  items are processed. The watcher now uses the target strategy version frozen
+  on the batch run rather than mutable namespace configuration.
+- Make namespace cleanup retryable after partial PostgreSQL, Redis, or Qdrant
+  failure, including when the namespace configuration row is already gone.
+- Coordinate compute, namespace deletion, and app reset with shared/exclusive
+  PostgreSQL maintenance advisory locks. App reset waits for active runs to
+  drain and blocks new runs until cleanup completes.
+- Propagate namespace configuration lookup failures during ingest so transient
+  infrastructure errors are retried instead of silently changing event weight.
+- Delete catalog vectors before deleting their durable PostgreSQL rows, keeping
+  failed external cleanup retryable.
+- Allow valid admin credentials to bypass an exhausted failed-attempt bucket,
+  preventing failed logins from locking out operators behind a shared proxy IP.
+
+### Changed
+
+- Recommendation cache keys now use the `rec:v2:*` format. Existing entries
+  are ignored and expire naturally, causing a temporary increase in cache misses
+  after deployment.
+- Deploy `api`, `admin`, `cron`, and `embedder` together for this release so all
+  processes use the same maintenance-lock and re-embed completion protocols.
+- Updated README, offline evaluation tooling, and Redis Streams SDK examples to
+  use `dense_source`, `occurred_at`, and the current catalog configuration API.
+- No public Go API or `pkg/codohuetypes` wire type changed. The planned Go module
+  `v0.5.1` tags are maintenance releases for corrected published documentation.
 
 ## v0.5.0 — 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ curl -b cookies.txt -X PUT http://localhost:2002/api/admin/v1/namespaces/demo \
     "lambda": 0.01, "gamma": 0.5,
     "max_results": 20, "seen_items_days": 14,
     "alpha": 0.7,
-    "dense_strategy": "byoe", "embedding_dim": 4, "dense_distance": "cosine",
+    "dense_source": "byoe", "embedding_dim": 4, "dense_distance": "cosine",
     "trending_window": 24, "trending_ttl": 600, "lambda_trending": 0.1
   }'
 ```
@@ -126,7 +126,7 @@ curl -X POST http://localhost:2001/v1/namespaces/demo/events \
 
 # Redis Streams (no URL → namespace lives in the payload)
 redis-cli XADD codohue:events '*' payload \
-  '{"namespace":"demo","subject_id":"user-123","object_id":"item-456","action":"VIEW","timestamp":"2026-04-19T10:00:00Z"}'
+  '{"namespace":"demo","subject_id":"user-123","object_id":"item-456","action":"VIEW","occurred_at":"2026-04-19T10:00:00Z"}'
 ```
 
 Built-in actions: `VIEW`, `LIKE`, `COMMENT`, `SHARE`, `SKIP`. Custom actions are accepted when defined in `namespace_configs.action_weights`.
@@ -198,4 +198,4 @@ make build-admin-embed    # production admin binary with SPA
 - Namespace keys are returned in plaintext **only once**, on creation.
 - Do not commit `.env`, secrets, or plaintext namespace keys.
 - `make down-v` removes containers **and** volumes — full local reset.
-- Catalog ingest (`POST /v1/namespaces/{ns}/catalog`) only works when `catalog_enabled = true` on the namespace; in that mode, `PUT /v1/namespaces/{ns}/objects/{id}/embedding` returns `409 Conflict` because the catalog pipeline owns object vectors.
+- Catalog ingest (`POST /v1/namespaces/{ns}/catalog`) only works when the namespace uses `dense_source="catalog"`, configured through `PUT /api/admin/v1/namespaces/{ns}/catalog`; in that mode, `PUT /v1/namespaces/{ns}/objects/{id}/embedding` returns `409 Conflict` because the catalog pipeline owns object vectors.

--- a/e2e/maintenance_lock_test.go
+++ b/e2e/maintenance_lock_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jarviisha/codohue/internal/compute"
+)
+
+func TestComputeMaintenanceLockCoordinatesAppReset(t *testing.T) {
+	repo := compute.NewRepository(testDB)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	releaseNamespace, err := repo.LockNamespace(ctx, "maintenance_lock_e2e")
+	if err != nil {
+		t.Fatalf("lock namespace: %v", err)
+	}
+	namespaceHeld := true
+	defer func() {
+		if namespaceHeld {
+			releaseNamespace()
+		}
+	}()
+
+	type lockResult struct {
+		release func()
+		err     error
+	}
+	maintenanceResult := make(chan lockResult, 1)
+	go func() {
+		release, lockErr := repo.LockAllNamespaces(ctx)
+		maintenanceResult <- lockResult{release: release, err: lockErr}
+	}()
+
+	select {
+	case result := <-maintenanceResult:
+		if result.release != nil {
+			result.release()
+		}
+		t.Fatalf("maintenance lock acquired before active namespace drained: %v", result.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	releaseNamespace()
+	namespaceHeld = false
+
+	var releaseMaintenance func()
+	select {
+	case result := <-maintenanceResult:
+		if result.err != nil {
+			t.Fatalf("lock all namespaces: %v", result.err)
+		}
+		releaseMaintenance = result.release
+	case <-ctx.Done():
+		t.Fatalf("maintenance lock did not acquire after namespace drained: %v", ctx.Err())
+	}
+
+	_, ok, err := repo.TryLockNamespace(ctx, "maintenance_lock_e2e")
+	if err != nil {
+		t.Fatalf("try namespace during maintenance: %v", err)
+	}
+	if ok {
+		t.Fatal("namespace lock acquired while exclusive maintenance lock was held")
+	}
+
+	releaseMaintenance()
+	release, ok, err := repo.TryLockNamespace(ctx, "maintenance_lock_e2e")
+	if err != nil {
+		t.Fatalf("try namespace after maintenance: %v", err)
+	}
+	if !ok {
+		t.Fatal("namespace lock remained blocked after maintenance lock release")
+	}
+	release()
+}

--- a/internal/admin/catalog_ops_repository.go
+++ b/internal/admin/catalog_ops_repository.go
@@ -201,6 +201,7 @@ func reembedResetSQL(onlyState string) string {
 		SET state = 'pending',
 		    attempt_count = 0,
 		    last_error = NULL,
+		    strategy_version = NULL,
 		    updated_at = NOW()
 		WHERE namespace = $1
 		  AND ` + stateCond + versionCond + `

--- a/internal/admin/catalog_ops_service.go
+++ b/internal/admin/catalog_ops_service.go
@@ -348,44 +348,33 @@ func (s *Service) BulkRedriveDeadletter(ctx context.Context, namespace string) (
 	}, nil
 }
 
-// DeleteCatalogItem removes a catalog item from Postgres and best-effort
-// removes the matching object dense vector from Qdrant. The path is
-// idempotent — deleting a non-existent item still returns 204 so retries
-// are safe.
+// DeleteCatalogItem removes the matching object dense vector before deleting
+// the catalog row. Keeping the durable row until external cleanup succeeds
+// makes a transient Qdrant failure retryable.
 func (s *Service) DeleteCatalogItem(ctx context.Context, namespace string, id int64) error {
-	objectID, found, err := s.repo.DeleteCatalogItem(ctx, namespace, id)
+	item, err := s.repo.GetCatalogItem(ctx, namespace, id)
 	if err != nil {
-		return fmt.Errorf("delete catalog item: %w", err)
+		return fmt.Errorf("get catalog item for delete: %w", err)
 	}
-	if !found {
-		// Idempotent — also try to delete by id directly so callers cannot
-		// break the API by referencing the row's id even after Postgres
-		// already lost it. This branch only matters for retries.
+	if item == nil {
 		return nil
 	}
 
-	if s.qdrantDeleter == nil {
-		return nil
+	if s.qdrantDeleter != nil {
+		numID, ok, lookupErr := s.repo.LookupNumericObjectID(ctx, namespace, item.ObjectID)
+		if lookupErr != nil {
+			return fmt.Errorf("lookup numeric object id: %w", lookupErr)
+		}
+		if ok {
+			if deleteErr := s.qdrantDeleter.DeletePoint(ctx, namespace+"_objects_dense", numID); deleteErr != nil {
+				return fmt.Errorf("delete qdrant point: %w", deleteErr)
+			}
+		}
 	}
-	numID, ok, err := s.repo.LookupNumericObjectID(ctx, namespace, objectID)
+
+	_, _, err = s.repo.DeleteCatalogItem(ctx, namespace, id)
 	if err != nil {
-		slog.WarnContext(ctx, "catalog delete: numeric id lookup failed; postgres row already deleted",
-			slog.String("namespace", namespace),
-			slog.String("object_id", objectID),
-			slog.String("error", err.Error()),
-		)
-		return nil
-	}
-	if !ok {
-		return nil
-	}
-	if err := s.qdrantDeleter.DeletePoint(ctx, namespace+"_objects_dense", numID); err != nil {
-		slog.WarnContext(ctx, "catalog delete: qdrant point removal failed; postgres row already deleted",
-			slog.String("namespace", namespace),
-			slog.String("object_id", objectID),
-			slog.String("collection", namespace+"_objects_dense"),
-			slog.String("error", err.Error()),
-		)
+		return fmt.Errorf("delete catalog item: %w", err)
 	}
 	return nil
 }

--- a/internal/admin/catalog_ops_service_test.go
+++ b/internal/admin/catalog_ops_service_test.go
@@ -384,6 +384,7 @@ func TestBulkRedriveDeadletter_Service_EmptyOK(t *testing.T) {
 
 func TestDeleteCatalogItem_Service_HappyPath(t *testing.T) {
 	repo := &fakeRepo{
+		getCatalogItem:          &CatalogItemDetail{CatalogItemSummary: CatalogItemSummary{ID: 7, ObjectID: "o7"}, Namespace: "ns"},
 		deleteCatalogItemFound:  true,
 		deleteCatalogItemObject: "o7",
 		numericObjectID:         123,
@@ -418,7 +419,10 @@ func TestDeleteCatalogItem_Service_PostgresMissIsIdempotent(t *testing.T) {
 }
 
 func TestDeleteCatalogItem_Service_PostgresErrorBubbles(t *testing.T) {
-	repo := &fakeRepo{deleteCatalogItemErr: fmt.Errorf("db down")}
+	repo := &fakeRepo{
+		getCatalogItem:       &CatalogItemDetail{CatalogItemSummary: CatalogItemSummary{ID: 1, ObjectID: "o1"}, Namespace: "ns"},
+		deleteCatalogItemErr: fmt.Errorf("db down"),
+	}
 	svc, _, _ := withCatalogPlumbing(t, repo, nil)
 
 	if err := svc.DeleteCatalogItem(context.Background(), "ns", 1); err == nil {
@@ -426,8 +430,9 @@ func TestDeleteCatalogItem_Service_PostgresErrorBubbles(t *testing.T) {
 	}
 }
 
-func TestDeleteCatalogItem_Service_QdrantMissIsBestEffort(t *testing.T) {
+func TestDeleteCatalogItem_Service_QdrantFailureIsRetryable(t *testing.T) {
 	repo := &fakeRepo{
+		getCatalogItem:          &CatalogItemDetail{CatalogItemSummary: CatalogItemSummary{ID: 7, ObjectID: "o7"}, Namespace: "ns"},
 		deleteCatalogItemFound:  true,
 		deleteCatalogItemObject: "o7",
 		numericObjectID:         99,
@@ -436,8 +441,11 @@ func TestDeleteCatalogItem_Service_QdrantMissIsBestEffort(t *testing.T) {
 	svc, _, del := withCatalogPlumbing(t, repo, nil)
 	del.err = errors.New("qdrant down")
 
-	if err := svc.DeleteCatalogItem(context.Background(), "ns", 7); err != nil {
-		t.Fatalf("qdrant failure must NOT bubble up: %v", err)
+	if err := svc.DeleteCatalogItem(context.Background(), "ns", 7); err == nil {
+		t.Fatal("qdrant failure must bubble up so the caller can retry")
+	}
+	if repo.deleteCatalogItemCalled != 0 {
+		t.Fatal("postgres row must remain until qdrant cleanup succeeds")
 	}
 }
 
@@ -486,6 +494,9 @@ func TestReembedResetSQL_StateFilters(t *testing.T) {
 		}
 		if strings.Contains(sql, tc.onlyState) && tc.onlyState == "bogus" {
 			t.Errorf("only_state=%q leaked into SQL text", tc.onlyState)
+		}
+		if !strings.Contains(sql, "strategy_version = NULL") {
+			t.Errorf("only_state=%q: reset must invalidate the previous strategy version", tc.onlyState)
 		}
 	}
 }

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -101,21 +100,21 @@ func (h *Handler) CreateSession(w http.ResponseWriter, r *http.Request) {
 		httpapi.WriteError(w, http.StatusServiceUnavailable, "sessions_unavailable", "session manager is not wired")
 		return
 	}
-	// Throttle the online guessing surface for the admin key: reject once the
-	// IP has burned its budget of FAILED attempts. Successful logins never
-	// consume the budget, so a legitimate operator is never throttled.
+	// Correct credentials bypass the failed-attempt bucket. This matters when
+	// several operators share a reverse-proxy IP: guesses from one client must
+	// not lock a legitimate operator out of the admin plane.
 	ip := clientIP(r)
-	if h.loginLimiter.Blocked(ip) {
-		httpapi.WriteError(w, http.StatusTooManyRequests, "rate_limited", "too many login attempts, retry later")
-		return
-	}
 
 	var req CreateSessionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := httpapi.DecodeStrict(r.Body, &req); err != nil {
 		httpapi.WriteError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
 		return
 	}
 	if !constantTimeEqual(req.APIKey, h.apiKey) {
+		if h.loginLimiter.Blocked(ip) {
+			httpapi.WriteError(w, http.StatusTooManyRequests, "rate_limited", "too many login attempts, retry later")
+			return
+		}
 		h.loginLimiter.RecordFailure(ip)
 		httpapi.WriteError(w, http.StatusUnauthorized, "unauthorized", "invalid api key")
 		return
@@ -273,7 +272,7 @@ func (h *Handler) UpdateCatalogConfig(w http.ResponseWriter, r *http.Request) {
 	ns := chi.URLParam(r, "ns")
 
 	var req NamespaceCatalogUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := httpapi.DecodeStrict(r.Body, &req); err != nil {
 		httpapi.WriteError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
 		return
 	}
@@ -567,7 +566,7 @@ func (h *Handler) InjectEvent(w http.ResponseWriter, r *http.Request) {
 	ns := chi.URLParam(r, "ns")
 
 	var req InjectEventRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := httpapi.DecodeStrict(r.Body, &req); err != nil {
 		httpapi.WriteError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
 		return
 	}
@@ -708,7 +707,7 @@ func (h *Handler) RotateNamespaceAPIKey(w http.ResponseWriter, r *http.Request) 
 // with 400 so a misclick or stray curl can't wipe the install.
 func (h *Handler) ResetApp(w http.ResponseWriter, r *http.Request) {
 	var req ResetAppRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := httpapi.DecodeStrict(r.Body, &req); err != nil {
 		httpapi.WriteError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
 		return
 	}

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1787,3 +1787,21 @@ func TestCreateSession_SuccessfulLoginsNotThrottled(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateSession_CorrectCredentialBypassesExhaustedSharedIPBucket(t *testing.T) {
+	h := newTestHandler(&fakeSvc{})
+	ip := "192.0.2.10"
+	for range loginBurst {
+		h.loginLimiter.RecordFailure(ip)
+	}
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/auth/sessions",
+		bytes.NewBufferString(`{"api_key":"test-secret"}`))
+	r.RemoteAddr = ip + ":1234"
+	h.CreateSession(rec, r)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("correct credential must bypass failed-attempt bucket, got %d", rec.Code)
+	}
+}

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -47,11 +47,11 @@ func RequireSessionOrBearer(sessions *SessionManager, adminKey string) func(http
 					return
 				}
 				ip := clientIP(r)
-				if limiter.Blocked(ip) {
-					httpapi.WriteError(w, http.StatusTooManyRequests, "rate_limited", "too many failed attempts; retry later")
-					return
-				}
 				if adminKey == "" || !constantTimeEqual(token, adminKey) {
+					if limiter.Blocked(ip) {
+						httpapi.WriteError(w, http.StatusTooManyRequests, "rate_limited", "too many failed attempts; retry later")
+						return
+					}
 					limiter.RecordFailure(ip)
 					httpapi.WriteError(w, http.StatusUnauthorized, "unauthorized", "invalid bearer token")
 					return

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -115,6 +116,9 @@ type batchRunner interface {
 	// LockNamespace blocks until the namespace's compute lock is free —
 	// taken by DeleteNamespace so a wipe never races a run in flight.
 	LockNamespace(ctx context.Context, namespace string) (release func(), err error)
+	// LockAllNamespaces waits for active compute/delete work to drain and
+	// blocks new work while ResetApp performs the app-wide wipe.
+	LockAllNamespaces(ctx context.Context) (release func(), err error)
 }
 
 // streamPublisher abstracts the Redis Streams write used by the catalog
@@ -882,10 +886,6 @@ func (s *Service) DeleteNamespace(ctx context.Context, namespace string) (*Names
 	if err != nil {
 		return nil, fmt.Errorf("get namespace: %w", err)
 	}
-	if cfg == nil {
-		return nil, nil
-	}
-
 	// Hold the namespace's compute lock for the whole wipe: a cron tick or
 	// manual run in flight would otherwise re-upsert Qdrant collections
 	// after the delete finishes, leaving orphans nothing ever cleans.
@@ -900,6 +900,9 @@ func (s *Service) DeleteNamespace(ctx context.Context, namespace string) (*Names
 	deleted, err := s.clearNamespaceEverywhere(ctx, namespace)
 	if err != nil {
 		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
 	}
 	return &NamespaceDeleteResponse{Namespace: namespace, EventsDeleted: deleted}, nil
 }
@@ -922,6 +925,16 @@ func (s *Service) ResetApp(ctx context.Context) (*ResetAppResponse, error) {
 	names := make([]string, 0, len(namespaces))
 	for _, ns := range namespaces {
 		names = append(names, ns.Namespace)
+	}
+	// The exclusive maintenance lock waits for all shared compute/delete
+	// holders to drain and blocks new work until the wipe is complete. It uses
+	// one connection regardless of namespace count.
+	if s.job != nil {
+		release, lockErr := s.job.LockAllNamespaces(ctx)
+		if lockErr != nil {
+			return nil, fmt.Errorf("acquire maintenance lock: %w", lockErr)
+		}
+		defer release()
 	}
 
 	eventsDeleted, nsDeleted, err := s.repo.TruncateAllNamespaceData(ctx)
@@ -1040,7 +1053,8 @@ func (s *Service) clearNamespaceRedis(ctx context.Context, namespace string) err
 		"trending:" + namespace,
 		"catalog:embed:" + namespace,
 	}
-	iter := s.redisClient.Scan(ctx, 0, "rec:"+namespace+":*", 100).Iterator()
+	encodedNamespace := base64.RawURLEncoding.EncodeToString([]byte(namespace))
+	iter := s.redisClient.Scan(ctx, 0, "rec:v2:"+encodedNamespace+":*", 100).Iterator()
 	for iter.Next(ctx) {
 		keys = append(keys, iter.Val())
 	}

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -741,9 +741,14 @@ func TestTriggerBatch_NamespaceNotFound(t *testing.T) {
 
 // fakeBatchRunner implements batchRunner for CreateBatchRun tests.
 type fakeBatchRunner struct {
-	runID    int64
-	startErr error
-	started  int
+	runID      int64
+	startErr   error
+	started    int
+	lockErr    error
+	locked     []string
+	released   []string
+	lockAll    int
+	releaseAll int
 }
 
 func (f *fakeBatchRunner) StartNamespaceRun(_ context.Context, _ string, _ batchrun.TriggerSource, _ time.Duration) (int64, error) {
@@ -751,8 +756,20 @@ func (f *fakeBatchRunner) StartNamespaceRun(_ context.Context, _ string, _ batch
 	return f.runID, f.startErr
 }
 
-func (f *fakeBatchRunner) LockNamespace(_ context.Context, _ string) (func(), error) {
-	return func() {}, nil
+func (f *fakeBatchRunner) LockNamespace(_ context.Context, namespace string) (func(), error) {
+	if f.lockErr != nil {
+		return nil, f.lockErr
+	}
+	f.locked = append(f.locked, namespace)
+	return func() { f.released = append(f.released, namespace) }, nil
+}
+
+func (f *fakeBatchRunner) LockAllNamespaces(_ context.Context) (func(), error) {
+	if f.lockErr != nil {
+		return nil, f.lockErr
+	}
+	f.lockAll++
+	return func() { f.releaseAll++ }, nil
 }
 
 func TestTriggerBatch_ConcurrentLock(t *testing.T) {
@@ -883,7 +900,7 @@ func TestDeleteNamespace_Success(t *testing.T) {
 	}
 }
 
-func TestDeleteNamespace_NotFound(t *testing.T) {
+func TestDeleteNamespace_NotFoundCleansOrphanedState(t *testing.T) {
 	repo := &fakeRepo{namespace: nil} // GetNamespace returns nil → 404 path
 	svc := newTestService(repo, "", "test-key")
 
@@ -894,8 +911,8 @@ func TestDeleteNamespace_NotFound(t *testing.T) {
 	if resp != nil {
 		t.Fatalf("expected nil response for missing namespace, got %+v", resp)
 	}
-	if len(repo.clearNamespaces) != 0 {
-		t.Fatalf("clear should not run when namespace missing, called for %v", repo.clearNamespaces)
+	if len(repo.clearNamespaces) != 1 || repo.clearNamespaces[0] != "missing" {
+		t.Fatalf("orphan cleanup should run when config is missing, called for %v", repo.clearNamespaces)
 	}
 }
 
@@ -911,6 +928,8 @@ func TestResetApp_TruncatesEverythingInOneCall(t *testing.T) {
 		truncateNamespaces: 3,
 	}
 	svc := newTestService(repo, "", "test-key")
+	runner := &fakeBatchRunner{}
+	svc.job = runner
 
 	resp, err := svc.ResetApp(context.Background())
 	if err != nil {
@@ -938,6 +957,12 @@ func TestResetApp_TruncatesEverythingInOneCall(t *testing.T) {
 		if resp.Namespaces[i] != ns {
 			t.Fatalf("Namespaces[%d]=%q, want %q", i, resp.Namespaces[i], ns)
 		}
+	}
+	if runner.lockAll != 1 {
+		t.Fatalf("maintenance lock calls=%d, want 1", runner.lockAll)
+	}
+	if runner.releaseAll != 1 {
+		t.Fatalf("maintenance lock releases=%d, want 1", runner.releaseAll)
 	}
 }
 

--- a/internal/compute/job.go
+++ b/internal/compute/job.go
@@ -87,6 +87,7 @@ type Job struct {
 	// injectable for testing — wired to real implementations in NewJob
 	tryLockFn                func(ctx context.Context, ns string) (release func(), ok bool, err error)
 	lockFn                   func(ctx context.Context, ns string) (release func(), err error)
+	lockAllFn                func(ctx context.Context) (release func(), err error)
 	finalizeOrphansFn        func(ctx context.Context, cutoff time.Time) (int64, error)
 	ensureCollectionsFn      func(ctx context.Context, ns string) error
 	ensureDenseCollectionsFn func(ctx context.Context, ns string, dim uint64, distance string) error
@@ -116,6 +117,7 @@ func NewJob(service *Service, nsConfigSvc jobNsConfigReader, repo *Repository, q
 
 		tryLockFn:         repo.TryLockNamespace,
 		lockFn:            repo.LockNamespace,
+		lockAllFn:         repo.LockAllNamespaces,
 		finalizeOrphansFn: repo.FinalizeOrphanRuns,
 		ensureCollectionsFn: func(ctx context.Context, ns string) error {
 			return infraqdrant.EnsureCollections(ctx, qdrantClient, ns)
@@ -282,6 +284,16 @@ func (j *Job) LockNamespace(ctx context.Context, ns string) (release func(), err
 	return j.lockFn(ctx, ns)
 }
 
+// LockAllNamespaces acquires the exclusive compute maintenance lock. Every
+// namespace run holds the shared form, so acquisition waits for active runs
+// to finish and blocks new ones until release.
+func (j *Job) LockAllNamespaces(ctx context.Context) (release func(), err error) {
+	if j.lockAllFn == nil {
+		return func() {}, nil
+	}
+	return j.lockAllFn(ctx)
+}
+
 // runNamespaceLocked executes the three phases and finalizes the run row.
 // The caller must hold the namespace lock. logID > 0 means the row was
 // already inserted (async path); 0 inserts it here.
@@ -335,8 +347,12 @@ func (j *Job) runNamespaceLocked(ctx context.Context, ns string, triggerSource b
 		phases.Phase2 = j.executePhase(ctx, logID, ns, 2, fmt.Sprintf("dense (%s)", cfg.DenseSource), capture, func() (int, int, error) {
 			return j.runPhase2Dense(ctx, ns, cfg, capture)
 		})
-		// Phase 2 failure is logged but does not abort the run — phase 3 still
-		// runs because trending and dense are independent surfaces.
+		// Dense and trending are independent, so phase 3 still runs after a
+		// dense failure. The aggregate run must nevertheless report failure:
+		// an all-green run means every phase that ran succeeded.
+		if !phases.Phase2.OK {
+			runErr = errors.New(phases.Phase2.Error)
+		}
 	} else if !cancelled && cfg != nil {
 		capture.Info(fmt.Sprintf("phase 2 · dense skipped (dense_source: %s)", cfg.DenseSource))
 	}

--- a/internal/compute/job_test.go
+++ b/internal/compute/job_test.go
@@ -765,6 +765,43 @@ func TestRunNamespace_Phase3FailureFailsRun(t *testing.T) {
 	}
 }
 
+func TestRunNamespace_Phase2FailureFailsRunAndContinuesToPhase3(t *testing.T) {
+	logger := newFakeBatchLogger(10)
+	successCh := make(chan bool, 1)
+	loggerWithSuccess := &successCapturingLogger{fakeBatchLogger: logger, success: successCh}
+
+	job := newTestJob(
+		&fakeRecomputer{},
+		&fakeNsConfigReader{cfg: &namespace.Config{DenseSource: "catalog", EmbeddingDim: 8}},
+		&fakeJobRepo{events: []*RawEvent{{SubjectID: "u1", ObjectID: "o1", Weight: 1, OccurredAt: time.Now().Unix()}}},
+	)
+	job.batchLog = loggerWithSuccess
+	job.ensureDenseCollectionsFn = func(_ context.Context, _ string, _ uint64, _ string) error {
+		return errors.New("qdrant unavailable")
+	}
+	job.redis = &goredis.Client{}
+	phase3Called := false
+	job.storeTrendingFn = func(_ context.Context, _ string, _ map[string]float64, _ time.Duration) error {
+		phase3Called = true
+		return nil
+	}
+
+	if err := job.RunNamespace(context.Background(), "ns1", batchrun.TriggerCron); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !phase3Called {
+		t.Fatal("trending phase must still run after an independent dense failure")
+	}
+	select {
+	case ok := <-successCh:
+		if ok {
+			t.Fatal("a run whose dense phase failed must not be recorded as success")
+		}
+	default:
+		t.Fatal("run was not finalized")
+	}
+}
+
 // successCapturingLogger records the success flag passed to UpdateBatchRunLog.
 type successCapturingLogger struct {
 	*fakeBatchLogger

--- a/internal/compute/repository.go
+++ b/internal/compute/repository.go
@@ -230,18 +230,29 @@ func (r *Repository) TryLockNamespace(ctx context.Context, namespace string) (re
 	if err != nil {
 		return nil, false, fmt.Errorf("acquire conn for advisory lock: %w", err)
 	}
+	var maintenanceOK bool
+	if lockErr := conn.QueryRow(ctx,
+		`SELECT pg_try_advisory_lock_shared(hashtext('codohue:compute:maintenance'), 0)`,
+	).Scan(&maintenanceOK); lockErr != nil {
+		conn.Release()
+		return nil, false, fmt.Errorf("acquire shared maintenance lock: %w", lockErr)
+	}
+	if !maintenanceOK {
+		conn.Release()
+		return nil, false, nil
+	}
 	var got bool
 	if lockErr := conn.QueryRow(ctx,
 		`SELECT pg_try_advisory_lock(hashtext('codohue:compute'), hashtext($1))`, namespace,
 	).Scan(&got); lockErr != nil {
-		conn.Release()
+		releaseSharedMaintenanceLock(conn)
 		return nil, false, fmt.Errorf("advisory lock %s: %w", namespace, lockErr)
 	}
 	if !got {
-		conn.Release()
+		releaseSharedMaintenanceLock(conn)
 		return nil, false, nil
 	}
-	return releaseLockFunc(conn, namespace), true, nil
+	return releaseNamespaceLockFunc(conn, namespace), true, nil
 }
 
 // LockNamespace is the blocking variant of TryLockNamespace — it waits until
@@ -253,28 +264,76 @@ func (r *Repository) LockNamespace(ctx context.Context, namespace string) (relea
 		return nil, fmt.Errorf("acquire conn for advisory lock: %w", err)
 	}
 	if _, lockErr := conn.Exec(ctx,
-		`SELECT pg_advisory_lock(hashtext('codohue:compute'), hashtext($1))`, namespace,
+		`SELECT pg_advisory_lock_shared(hashtext('codohue:compute:maintenance'), 0)`,
 	); lockErr != nil {
 		conn.Release()
+		return nil, fmt.Errorf("acquire shared maintenance lock: %w", lockErr)
+	}
+	if _, lockErr := conn.Exec(ctx,
+		`SELECT pg_advisory_lock(hashtext('codohue:compute'), hashtext($1))`, namespace,
+	); lockErr != nil {
+		releaseSharedMaintenanceLock(conn)
 		return nil, fmt.Errorf("advisory lock %s: %w", namespace, lockErr)
 	}
-	return releaseLockFunc(conn, namespace), nil
+	return releaseNamespaceLockFunc(conn, namespace), nil
 }
 
-func releaseLockFunc(conn *pgxpool.Conn, namespace string) func() {
+// LockAllNamespaces acquires the exclusive maintenance lock. Namespace runs
+// and deletes hold its shared form, so this waits for all of them to drain
+// without pinning one pool connection per namespace.
+func (r *Repository) LockAllNamespaces(ctx context.Context) (release func(), err error) {
+	conn, err := r.db.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn for maintenance lock: %w", err)
+	}
+	if _, lockErr := conn.Exec(ctx,
+		`SELECT pg_advisory_lock(hashtext('codohue:compute:maintenance'), 0)`,
+	); lockErr != nil {
+		conn.Release()
+		return nil, fmt.Errorf("acquire maintenance lock: %w", lockErr)
+	}
+	return releaseMaintenanceLockFunc(conn), nil
+}
+
+func releaseNamespaceLockFunc(conn *pgxpool.Conn, namespace string) func() {
 	return func() {
 		// Unlock on a fresh context: the run's ctx may already be cancelled.
 		unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if _, unlockErr := conn.Exec(unlockCtx,
+		_, namespaceErr := conn.Exec(unlockCtx,
 			`SELECT pg_advisory_unlock(hashtext('codohue:compute'), hashtext($1))`, namespace,
-		); unlockErr != nil {
+		)
+		_, maintenanceErr := conn.Exec(unlockCtx,
+			`SELECT pg_advisory_unlock_shared(hashtext('codohue:compute:maintenance'), 0)`,
+		)
+		if namespaceErr != nil || maintenanceErr != nil {
 			// A pooled connection keeps its session (and thus the lock) alive,
 			// so on unlock failure the connection must die with the lock.
 			conn.Conn().Close(unlockCtx) //nolint:errcheck,gosec // best-effort teardown; Release below discards the closed conn
 		}
 		conn.Release()
 	}
+}
+
+func releaseSharedMaintenanceLock(conn *pgxpool.Conn) {
+	releaseMaintenanceLock(conn, true)
+}
+
+func releaseMaintenanceLockFunc(conn *pgxpool.Conn) func() {
+	return func() { releaseMaintenanceLock(conn, false) }
+}
+
+func releaseMaintenanceLock(conn *pgxpool.Conn, shared bool) {
+	unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	query := `SELECT pg_advisory_unlock(hashtext('codohue:compute:maintenance'), 0)`
+	if shared {
+		query = `SELECT pg_advisory_unlock_shared(hashtext('codohue:compute:maintenance'), 0)`
+	}
+	if _, unlockErr := conn.Exec(unlockCtx, query); unlockErr != nil {
+		conn.Conn().Close(unlockCtx) //nolint:errcheck,gosec // discard session if its advisory lock could not be released
+	}
+	conn.Release()
 }
 
 // FinalizeOrphanRuns closes batch_run_logs rows whose owning process died

--- a/internal/compute/repository_test.go
+++ b/internal/compute/repository_test.go
@@ -173,3 +173,59 @@ func TestRepositoryGetNamespaceEventsInWindow(t *testing.T) {
 		t.Errorf("expected item-recent, got %q", events[0].ObjectID)
 	}
 }
+
+func TestRepositoryAdvisoryLocks(t *testing.T) {
+	db := openTestDB(t)
+	competingDB := openTestDB(t)
+	repo := NewRepository(db)
+	competingRepo := NewRepository(competingDB)
+	ctx := context.Background()
+
+	releaseNamespace, got, err := repo.TryLockNamespace(ctx, "compute_lock_test")
+	if err != nil {
+		t.Fatalf("TryLockNamespace: %v", err)
+	}
+	if !got {
+		t.Fatal("TryLockNamespace did not acquire an uncontended lock")
+	}
+
+	blockedRelease, blocked, err := competingRepo.TryLockNamespace(ctx, "compute_lock_test")
+	if err != nil {
+		t.Fatalf("second TryLockNamespace: %v", err)
+	}
+	if blocked {
+		blockedRelease()
+		t.Fatal("second TryLockNamespace acquired the same namespace lock")
+	}
+	releaseNamespace()
+
+	releaseBlocking, err := repo.LockNamespace(ctx, "compute_lock_test")
+	if err != nil {
+		t.Fatalf("LockNamespace after release: %v", err)
+	}
+	releaseBlocking()
+
+	releaseMaintenance, err := repo.LockAllNamespaces(ctx)
+	if err != nil {
+		t.Fatalf("LockAllNamespaces: %v", err)
+	}
+
+	blockedRelease, blocked, err = competingRepo.TryLockNamespace(ctx, "compute_lock_test")
+	if err != nil {
+		t.Fatalf("TryLockNamespace during maintenance: %v", err)
+	}
+	if blocked {
+		blockedRelease()
+		t.Fatal("TryLockNamespace acquired a shared lock during maintenance")
+	}
+	releaseMaintenance()
+
+	releaseAfterMaintenance, got, err := repo.TryLockNamespace(ctx, "compute_lock_test")
+	if err != nil {
+		t.Fatalf("TryLockNamespace after maintenance: %v", err)
+	}
+	if !got {
+		t.Fatal("TryLockNamespace did not acquire the lock after maintenance release")
+	}
+	releaseAfterMaintenance()
+}

--- a/internal/core/httpapi/httpapi.go
+++ b/internal/core/httpapi/httpapi.go
@@ -10,6 +10,11 @@ import (
 	"github.com/jarviisha/codohue/pkg/codohuetypes"
 )
 
+const defaultMaxJSONBodyBytes int64 = 8 << 20
+
+// ErrBodyTooLarge indicates that a JSON request exceeded the hard decoder cap.
+var ErrBodyTooLarge = errors.New("request body too large")
+
 // ErrorDetail is the machine-readable error payload returned by API handlers.
 // Re-exported from codohuetypes so SDK clients parse the same struct.
 type ErrorDetail = codohuetypes.ErrorDetail
@@ -24,15 +29,33 @@ type ErrorResponse = codohuetypes.ErrorResponse
 // field fails loudly with an error instead of being silently dropped. The
 // caller maps the returned error to its own 400 envelope and metrics.
 func DecodeStrict(r io.Reader, v any) error {
-	dec := json.NewDecoder(r)
+	return DecodeStrictMax(r, v, defaultMaxJSONBodyBytes)
+}
+
+// DecodeStrictMax is DecodeStrict with an explicit byte cap. The decoder reads
+// at most maxBytes+1, so an authenticated request cannot force an unbounded
+// string, slice, or map allocation before business validation runs.
+func DecodeStrictMax(r io.Reader, v any, maxBytes int64) error {
+	if maxBytes <= 0 {
+		return ErrBodyTooLarge
+	}
+	limited := &io.LimitedReader{R: r, N: maxBytes + 1}
+	dec := json.NewDecoder(limited)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(v); err != nil {
+		if limited.N == 0 {
+			return ErrBodyTooLarge
+		}
 		return fmt.Errorf("decode request body: %w", err)
 	}
-	// A well-formed request body is a single JSON value; reject anything that
-	// follows it (e.g. a second concatenated object).
-	if dec.More() {
+	var extra any
+	if err := dec.Decode(&extra); err == nil {
 		return errors.New("unexpected trailing data after JSON body")
+	} else if !errors.Is(err, io.EOF) {
+		if limited.N == 0 {
+			return ErrBodyTooLarge
+		}
+		return fmt.Errorf("decode trailing request data: %w", err)
 	}
 	return nil
 }

--- a/internal/core/httpapi/httpapi_test.go
+++ b/internal/core/httpapi/httpapi_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -49,5 +50,15 @@ func TestDecodeStrict_RejectsMalformedJSON(t *testing.T) {
 	}
 	if err := DecodeStrict(strings.NewReader(`not-json`), &out); err == nil {
 		t.Fatal("expected an error for malformed JSON, got nil")
+	}
+}
+
+func TestDecodeStrictMax_RejectsOversizedBody(t *testing.T) {
+	var out struct {
+		Value string `json:"value"`
+	}
+	err := DecodeStrictMax(strings.NewReader(`{"value":"123456789"}`), &out, 8)
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("expected ErrBodyTooLarge, got %v", err)
 	}
 }

--- a/internal/embedder/reembed_watcher.go
+++ b/internal/embedder/reembed_watcher.go
@@ -2,13 +2,11 @@ package embedder
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/jarviisha/codohue/internal/core/batchrun"
@@ -16,17 +14,18 @@ import (
 
 // ReembedRun is the watcher's view of one open re-embed batch_run_logs row.
 type ReembedRun struct {
-	ID        int64
-	Namespace string
-	StartedAt time.Time
+	ID                    int64
+	Namespace             string
+	TargetStrategyVersion string
+	StartedAt             time.Time
 }
 
 // ReembedWatcherRepo is the storage surface required by ReembedWatcher.
 // Defined here so the watcher tests can mock storage without a real DB.
 type ReembedWatcherRepo interface {
 	ListOpenReembedRuns(ctx context.Context) ([]ReembedRun, error)
-	CountStaleCatalogItems(ctx context.Context, namespace string) (int, error)
-	CountEmbeddedCatalogItems(ctx context.Context, namespace string) (int, error)
+	CountStaleCatalogItems(ctx context.Context, namespace, targetStrategyVersion string) (int, error)
+	CountEmbeddedCatalogItems(ctx context.Context, namespace, targetStrategyVersion string) (int, error)
 	CompleteReembedRun(ctx context.Context, id int64, processed int, success bool, errorMessage string, completedAt time.Time, durationMs int) error
 }
 
@@ -95,7 +94,7 @@ func (w *ReembedWatcher) tick(ctx context.Context) {
 	}
 
 	for _, run := range runs {
-		stale, err := w.repo.CountStaleCatalogItems(ctx, run.Namespace)
+		stale, err := w.repo.CountStaleCatalogItems(ctx, run.Namespace, run.TargetStrategyVersion)
 		if err != nil {
 			slog.WarnContext(ctx, "reembed watcher: count stale items failed",
 				slog.Int64("batch_run_id", run.ID),
@@ -107,7 +106,7 @@ func (w *ReembedWatcher) tick(ctx context.Context) {
 		// Emit progress every tick (even when stale > 0) so the SPA
 		// overlay updates while the run is still in flight. embedded =
 		// processed; embedded + stale = total expected.
-		processed, err := w.repo.CountEmbeddedCatalogItems(ctx, run.Namespace)
+		processed, err := w.repo.CountEmbeddedCatalogItems(ctx, run.Namespace, run.TargetStrategyVersion)
 		if err != nil {
 			slog.WarnContext(ctx, "reembed watcher: count embedded items failed",
 				slog.Int64("batch_run_id", run.ID),
@@ -163,7 +162,7 @@ func NewPgReembedRepo(db *pgxpool.Pool) ReembedWatcherRepo {
 // re-embed orchestrator that has not yet been closed.
 func (r *pgReembedRepo) ListOpenReembedRuns(ctx context.Context) ([]ReembedRun, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, namespace, started_at
+		SELECT id, namespace, COALESCE(target_strategy_version, ''), started_at
 		FROM batch_run_logs
 		WHERE trigger_source = $1
 		  AND completed_at IS NULL`,
@@ -177,7 +176,7 @@ func (r *pgReembedRepo) ListOpenReembedRuns(ctx context.Context) ([]ReembedRun, 
 	var out []ReembedRun
 	for rows.Next() {
 		var run ReembedRun
-		if err := rows.Scan(&run.ID, &run.Namespace, &run.StartedAt); err != nil {
+		if err := rows.Scan(&run.ID, &run.Namespace, &run.TargetStrategyVersion, &run.StartedAt); err != nil {
 			return nil, fmt.Errorf("scan reembed run: %w", err)
 		}
 		out = append(out, run)
@@ -189,29 +188,23 @@ func (r *pgReembedRepo) ListOpenReembedRuns(ctx context.Context) ([]ReembedRun, 
 }
 
 // CountStaleCatalogItems returns the number of catalog_items in the namespace
-// that still need processing under the namespace's currently configured
-// catalog_strategy_version. Items in 'pending', 'in_flight', or 'failed' state
-// AND whose strategy_version is NULL or differs from the namespace's
-// current target are counted.
+// that still need processing under the target strategy version frozen on the
+// batch run. Items in 'pending', 'in_flight', or 'failed' state whose version
+// is NULL or differs from that target are counted.
 //
 // Items in 'dead_letter' are NOT counted — they require explicit operator
 // redrive via the admin API and should not block re-embed completion (per R6).
 // Items in 'embedded' state at the right version are also excluded.
-func (r *pgReembedRepo) CountStaleCatalogItems(ctx context.Context, namespace string) (int, error) {
+func (r *pgReembedRepo) CountStaleCatalogItems(ctx context.Context, namespace, targetStrategyVersion string) (int, error) {
 	var n int
 	err := r.db.QueryRow(ctx, `
 		SELECT COUNT(*)
-		FROM catalog_items ci
-		JOIN namespace_configs nc ON nc.namespace = ci.namespace
-		WHERE ci.namespace = $1
-		  AND ci.state IN ('pending', 'in_flight', 'failed')
-		  AND (ci.strategy_version IS NULL
-		       OR ci.strategy_version <> nc.catalog_strategy_version)`,
-		namespace,
+		FROM catalog_items
+		WHERE namespace = $1
+		  AND state IN ('pending', 'in_flight', 'failed')
+		  AND (strategy_version IS NULL OR strategy_version <> $2)`,
+		namespace, targetStrategyVersion,
 	).Scan(&n)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, nil
-	}
 	if err != nil {
 		return 0, fmt.Errorf("count stale catalog items: %w", err)
 	}
@@ -219,18 +212,17 @@ func (r *pgReembedRepo) CountStaleCatalogItems(ctx context.Context, namespace st
 }
 
 // CountEmbeddedCatalogItems returns the number of catalog_items currently in
-// 'embedded' state at the namespace's active strategy version. Used as the
+// 'embedded' state at the batch run's target strategy version. Used as the
 // "entities_processed" tally written to batch_run_logs on completion.
-func (r *pgReembedRepo) CountEmbeddedCatalogItems(ctx context.Context, namespace string) (int, error) {
+func (r *pgReembedRepo) CountEmbeddedCatalogItems(ctx context.Context, namespace, targetStrategyVersion string) (int, error) {
 	var n int
 	err := r.db.QueryRow(ctx, `
 		SELECT COUNT(*)
-		FROM catalog_items ci
-		JOIN namespace_configs nc ON nc.namespace = ci.namespace
-		WHERE ci.namespace = $1
-		  AND ci.state = 'embedded'
-		  AND ci.strategy_version = nc.catalog_strategy_version`,
-		namespace,
+		FROM catalog_items
+		WHERE namespace = $1
+		  AND state = 'embedded'
+		  AND strategy_version = $2`,
+		namespace, targetStrategyVersion,
 	).Scan(&n)
 	if err != nil {
 		return 0, fmt.Errorf("count embedded catalog items: %w", err)

--- a/internal/embedder/reembed_watcher_test.go
+++ b/internal/embedder/reembed_watcher_test.go
@@ -12,14 +12,16 @@ import (
 type fakeReembedRepo struct {
 	mu sync.Mutex
 
-	openRuns       []ReembedRun
-	listErr        error
-	staleCount     map[string]int
-	staleErr       error
-	embeddedCount  map[string]int
-	embeddedErr    error
-	completeErr    error
-	completedCalls []completeCall
+	openRuns        []ReembedRun
+	listErr         error
+	staleCount      map[string]int
+	staleErr        error
+	embeddedCount   map[string]int
+	embeddedErr     error
+	staleTargets    []string
+	embeddedTargets []string
+	completeErr     error
+	completedCalls  []completeCall
 }
 
 type completeCall struct {
@@ -41,18 +43,20 @@ func (f *fakeReembedRepo) ListOpenReembedRuns(_ context.Context) ([]ReembedRun, 
 	return out, nil
 }
 
-func (f *fakeReembedRepo) CountStaleCatalogItems(_ context.Context, ns string) (int, error) {
+func (f *fakeReembedRepo) CountStaleCatalogItems(_ context.Context, ns, target string) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.staleTargets = append(f.staleTargets, target)
 	if f.staleErr != nil {
 		return 0, f.staleErr
 	}
 	return f.staleCount[ns], nil
 }
 
-func (f *fakeReembedRepo) CountEmbeddedCatalogItems(_ context.Context, ns string) (int, error) {
+func (f *fakeReembedRepo) CountEmbeddedCatalogItems(_ context.Context, ns, target string) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.embeddedTargets = append(f.embeddedTargets, target)
 	if f.embeddedErr != nil {
 		return 0, f.embeddedErr
 	}
@@ -88,7 +92,7 @@ func TestReembedWatcher_CompletesWhenBacklogEmpty(t *testing.T) {
 	startedAt := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 	repo := &fakeReembedRepo{
 		openRuns: []ReembedRun{
-			{ID: 11, Namespace: "ns", StartedAt: startedAt},
+			{ID: 11, Namespace: "ns", TargetStrategyVersion: "v2", StartedAt: startedAt},
 		},
 		staleCount:    map[string]int{"ns": 0},
 		embeddedCount: map[string]int{"ns": 25},
@@ -107,6 +111,10 @@ func TestReembedWatcher_CompletesWhenBacklogEmpty(t *testing.T) {
 	}
 	if got.duration != 3000 {
 		t.Errorf("expected duration_ms=3000, got %d", got.duration)
+	}
+	if len(repo.staleTargets) != 1 || repo.staleTargets[0] != "v2" ||
+		len(repo.embeddedTargets) != 1 || repo.embeddedTargets[0] != "v2" {
+		t.Fatalf("watcher did not use frozen target version: stale=%v embedded=%v", repo.staleTargets, repo.embeddedTargets)
 	}
 }
 

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -62,5 +62,5 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 }
 
 func isClientPayloadError(err error) bool {
-	return errors.Is(err, ErrInvalidPayload) || errors.Is(err, ErrUnknownAction)
+	return errors.Is(err, ErrInvalidPayload) || errors.Is(err, ErrUnknownAction) || errors.Is(err, ErrNamespaceNotFound)
 }

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -20,6 +20,8 @@ var (
 	ErrInvalidPayload = errors.New("invalid payload")
 	// ErrUnknownAction indicates that the event action cannot be resolved to a configured or default weight.
 	ErrUnknownAction = errors.New("unknown action")
+	// ErrNamespaceNotFound indicates that an event targets a namespace that no longer exists.
+	ErrNamespaceNotFound = errors.New("namespace not found")
 )
 
 type eventInserter interface {
@@ -73,7 +75,13 @@ func (s *Service) Process(ctx context.Context, payload *EventPayload) (int64, er
 
 	weight, err := s.resolveWeight(ctx, payload.Namespace, payload.Action)
 	if err != nil {
-		metrics.IngestErrorsTotal.WithLabelValues(payload.Namespace, "unknown_action").Inc()
+		reason := "config"
+		if errors.Is(err, ErrUnknownAction) {
+			reason = "unknown_action"
+		} else if errors.Is(err, ErrNamespaceNotFound) {
+			reason = "unknown_namespace"
+		}
+		metrics.IngestErrorsTotal.WithLabelValues(payload.Namespace, reason).Inc()
 		return 0, fmt.Errorf("resolve weight: %w", err)
 	}
 
@@ -109,10 +117,14 @@ func (s *Service) Process(ctx context.Context, payload *EventPayload) (int64, er
 
 func (s *Service) resolveWeight(ctx context.Context, ns string, action Action) (float64, error) {
 	cfg, err := s.nsConfigSvc.Get(ctx, ns)
-	if err == nil && cfg != nil {
-		if w, ok := cfg.ActionWeights[string(action)]; ok {
-			return w, nil
-		}
+	if err != nil {
+		return 0, fmt.Errorf("get namespace config: %w", err)
+	}
+	if cfg == nil {
+		return 0, fmt.Errorf("%w: %s", ErrNamespaceNotFound, ns)
+	}
+	if w, ok := cfg.ActionWeights[string(action)]; ok {
+		return w, nil
 	}
 
 	if w, ok := DefaultActionWeights[action]; ok {

--- a/internal/ingest/service_test.go
+++ b/internal/ingest/service_test.go
@@ -39,12 +39,19 @@ func (f *fakeTailPublisher) Publish(msg EventTailMessage) {
 
 // fakeNsConfig implements nsConfigGetter for testing.
 type fakeNsConfig struct {
-	cfg *namespace.Config
-	err error
+	cfg     *namespace.Config
+	err     error
+	missing bool
 }
 
 func (f *fakeNsConfig) Get(_ context.Context, _ string) (*namespace.Config, error) {
-	return f.cfg, f.err
+	if f.err != nil || f.missing {
+		return f.cfg, f.err
+	}
+	if f.cfg == nil {
+		return &namespace.Config{}, nil
+	}
+	return f.cfg, nil
 }
 
 func newTestService(repo eventInserter, ns nsConfigGetter) *Service {
@@ -83,7 +90,7 @@ func TestServiceProcess_Validation(t *testing.T) {
 
 func TestServiceProcess_DefaultWeight(t *testing.T) {
 	repo := &fakeRepo{}
-	svc := newTestService(repo, &fakeNsConfig{cfg: nil})
+	svc := newTestService(repo, &fakeNsConfig{cfg: &namespace.Config{}})
 
 	if _, err := svc.Process(context.Background(), &EventPayload{
 		Namespace: "ns", SubjectID: "u1", ObjectID: "o1",
@@ -120,19 +127,34 @@ func TestServiceProcess_CustomNamespaceWeight(t *testing.T) {
 	}
 }
 
-func TestServiceProcess_NsConfigError_FallsBackToDefault(t *testing.T) {
+func TestServiceProcess_NsConfigErrorIsTransient(t *testing.T) {
 	repo := &fakeRepo{}
 	svc := newTestService(repo, &fakeNsConfig{err: errors.New("db error")})
 
 	if _, err := svc.Process(context.Background(), &EventPayload{
 		Namespace: "ns", SubjectID: "u1", ObjectID: "o1",
 		Action: ActionView, OccurredAt: time.Now(),
-	}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	}); err == nil {
+		t.Fatal("config infrastructure error must be returned for retry")
 	}
+	if repo.insertCalled {
+		t.Fatal("event must not be inserted with an unverified default weight")
+	}
+}
 
-	if repo.lastEvent.Weight != DefaultActionWeights[ActionView] {
-		t.Errorf("weight: got %.1f, want %.1f", repo.lastEvent.Weight, DefaultActionWeights[ActionView])
+func TestServiceProcess_MissingNamespaceRejected(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := newTestService(repo, &fakeNsConfig{missing: true})
+
+	_, err := svc.Process(context.Background(), &EventPayload{
+		Namespace: "ghost", SubjectID: "u1", ObjectID: "o1",
+		Action: ActionView, OccurredAt: time.Now(),
+	})
+	if !errors.Is(err, ErrNamespaceNotFound) {
+		t.Fatalf("expected ErrNamespaceNotFound, got %v", err)
+	}
+	if repo.insertCalled {
+		t.Fatal("event for missing namespace must not be inserted")
 	}
 }
 

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -203,7 +203,7 @@ func (w *Worker) handleMessage(ctx context.Context, msg redis.XMessage) {
 	}
 
 	if _, err := w.service.Process(ctx, payload); err != nil {
-		if errors.Is(err, ErrInvalidPayload) || errors.Is(err, ErrUnknownAction) {
+		if errors.Is(err, ErrInvalidPayload) || errors.Is(err, ErrUnknownAction) || errors.Is(err, ErrNamespaceNotFound) {
 			slog.Warn("ingest dropping unprocessable event", "entry_id", msg.ID, "error", err)
 			w.ack(ctx, msg.ID)
 			return

--- a/internal/ingest/worker_test.go
+++ b/internal/ingest/worker_test.go
@@ -94,7 +94,7 @@ func TestWorkerHandleMessage_TransientErrorLeavesEntryPending(t *testing.T) {
 }
 
 func TestWorkerHandleMessage_PermanentErrorAckedAndDropped(t *testing.T) {
-	for _, sentinel := range []error{ErrInvalidPayload, ErrUnknownAction} {
+	for _, sentinel := range []error{ErrInvalidPayload, ErrUnknownAction, ErrNamespaceNotFound} {
 		proc := &fakeProcessor{processErr: fmt.Errorf("wrapped: %w", sentinel)}
 		acked := []string{}
 		w := &Worker{service: proc, ackFn: ackRecorder(&acked)}

--- a/internal/recommend/service.go
+++ b/internal/recommend/service.go
@@ -2,6 +2,7 @@ package recommend
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -291,7 +292,8 @@ func (s *Service) Recommend(ctx context.Context, req *Request) (*Response, error
 	cacheKey := recCacheKey(req.Namespace, req.SubjectID, maxResults, req.Offset)
 	if cached, err := s.getCacheFn(ctx, cacheKey); err == nil {
 		var resp Response
-		if json.Unmarshal([]byte(cached), &resp) == nil {
+		if json.Unmarshal([]byte(cached), &resp) == nil &&
+			resp.Namespace == req.Namespace && resp.SubjectID == req.SubjectID {
 			metrics.RedisCacheRequests.WithLabelValues("hit").Inc()
 			return &resp, nil
 		}
@@ -1451,7 +1453,12 @@ func (s *Service) deleteFromCollection(ctx context.Context, collection string, i
 }
 
 func recCacheKey(ns, subjectID string, limit, offset int) string {
-	return fmt.Sprintf("rec:%s:%s:limit=%d:offset=%d", ns, subjectID, limit, offset)
+	return fmt.Sprintf("rec:v2:%s:%s:limit=%d:offset=%d",
+		base64.RawURLEncoding.EncodeToString([]byte(ns)),
+		base64.RawURLEncoding.EncodeToString([]byte(subjectID)),
+		limit,
+		offset,
+	)
 }
 
 // mergeExclusions unions two exclusion sets, returning nil when both are

--- a/internal/recommend/service_test.go
+++ b/internal/recommend/service_test.go
@@ -202,6 +202,22 @@ func TestRecommend_CacheHit(t *testing.T) {
 	}
 }
 
+func TestRecommend_IgnoresCacheEntryForDifferentIdentity(t *testing.T) {
+	repo := &fakeRepo{count: 0, popularItems: []string{"fresh-item"}}
+	s := newTestService(repo, &fakeNsConfig{}, newFakeIDMapper())
+	s.getCacheFn = func(_ context.Context, _ string) (string, error) {
+		return `{"subject_id":"other","namespace":"tenant","items":[{"object_id":"cached-item","rank":1}]}`, nil
+	}
+
+	resp, err := s.Recommend(context.Background(), &Request{SubjectID: "u1", Namespace: "ns", Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].ObjectID != "fresh-item" {
+		t.Fatalf("mismatched cache identity must be ignored, got %+v", resp.Items)
+	}
+}
+
 // ─── doRecommend: cold start (count=0) ───────────────────────────────────────
 
 func TestDoRecommend_ColdStart_NoTrending_FallsBackToPopular(t *testing.T) {
@@ -1655,15 +1671,23 @@ func TestDeleteFromCollection_Error(t *testing.T) {
 
 func TestRecCacheKey(t *testing.T) {
 	key := recCacheKey("ns_feed", "user123", 20, 0)
-	want := "rec:ns_feed:user123:limit=20:offset=0"
+	want := "rec:v2:bnNfZmVlZA:dXNlcjEyMw:limit=20:offset=0"
 	if key != want {
 		t.Errorf("got %q, want %q", key, want)
 	}
 
 	keyWithOffset := recCacheKey("ns_feed", "user123", 20, 10)
-	wantWithOffset := "rec:ns_feed:user123:limit=20:offset=10"
+	wantWithOffset := "rec:v2:bnNfZmVlZA:dXNlcjEyMw:limit=20:offset=10"
 	if keyWithOffset != wantWithOffset {
 		t.Errorf("got %q, want %q", keyWithOffset, wantWithOffset)
+	}
+}
+
+func TestRecCacheKey_DelimiterCannotCollide(t *testing.T) {
+	first := recCacheKey("a", "b:c", 20, 0)
+	second := recCacheKey("a:b", "c", 20, 0)
+	if first == second {
+		t.Fatalf("cache keys collided: %q", first)
 	}
 }
 

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -24,7 +24,7 @@ How it works (classic temporal leave-last-N-out protocol):
 REAL DATA: pass --from-namespace NS to evaluate genuine recorded behaviour
 instead of synthetic data. Its events are read via the admin API, temporal-
 split, and replayed into a SEPARATE eval namespace (the source is never
-touched). Config (action_weights, alpha, dense_strategy, ...) is inherited from
+touched). Config (action_weights, alpha, dense_source, ...) is inherited from
 the source namespace unless overridden by flags. This is the only number that
 reflects real-world quality; the synthetic mode validates the mechanism.
 
@@ -490,6 +490,7 @@ def main() -> int:
     )
     p.add_argument(
         "--dense-strategy",
+        dest="dense_source",
         default=None,
         choices=["disabled", "item2vec", "svd"],
         help="dense strategy trained during the batch run (needs alpha<1.0 to actually blend)",
@@ -534,12 +535,12 @@ def main() -> int:
         # Inherit source config; CLI flags override. BYOE can't be replayed (no
         # external vectors) so it degrades to pure sparse.
         action_weights = scfg.get("action_weights") or ACTION_WEIGHTS
-        src_dense = scfg.get("dense_strategy") or "disabled"
+        src_dense = scfg.get("dense_source") or "disabled"
         if src_dense not in ("item2vec", "svd"):
             src_dense = "disabled"
         alpha = args.alpha if args.alpha is not None else scfg.get("alpha", 1.0)
-        dense_strategy = (
-            args.dense_strategy if args.dense_strategy is not None else src_dense
+        dense_source = (
+            args.dense_source if args.dense_source is not None else src_dense
         )
         embedding_dim = (
             args.embedding_dim
@@ -564,8 +565,8 @@ def main() -> int:
         )
         action_weights = ACTION_WEIGHTS
         alpha = args.alpha if args.alpha is not None else 1.0
-        dense_strategy = (
-            args.dense_strategy if args.dense_strategy is not None else "disabled"
+        dense_source = (
+            args.dense_source if args.dense_source is not None else "disabled"
         )
         embedding_dim = args.embedding_dim if args.embedding_dim is not None else 64
         lam = 0.01
@@ -581,11 +582,11 @@ def main() -> int:
     for a in actions_present:
         action_weights.setdefault(a, 1.0)
 
-    dense_active = dense_strategy not in ("disabled", "byoe", "")
+    dense_active = dense_source not in ("disabled", "byoe", "")
     hybrid = dense_active and alpha < 1.0
     if dense_active and alpha >= 1.0:
         print(
-            f"{YELLOW}note:{RESET} dense_strategy={dense_strategy} but alpha>=1.0 — dense trained but unused (pure CF). Pass --alpha<1.0."
+            f"{YELLOW}note:{RESET} dense_source={dense_source} but alpha>=1.0 — dense trained but unused (pure CF). Pass --alpha<1.0."
         )
     if not dense_active and alpha is not None and alpha < 1.0:
         print(
@@ -594,18 +595,18 @@ def main() -> int:
 
     mode = "hybrid (sparse+dense)" if hybrid else "pure sparse CF"
     n_events_train = sum(len(v) for v in train.values())
-    note(f"mode={mode}  alpha={alpha}  dense_strategy={dense_strategy}")
+    note(f"mode={mode}  alpha={alpha}  dense_source={dense_source}")
     note(
         f"{len(train)} eligible users, {n_events_train} train events, {len(test)} test users, {n_items} items"
     )
 
     # 2. fresh eval namespace (wipe clears events + qdrant + rec cache)
-    section(f"Provision eval namespace ({mode}: alpha={alpha}, dense={dense_strategy})")
+    section(f"Provision eval namespace ({mode}: alpha={alpha}, dense={dense_source})")
     admin("DELETE", f"/api/admin/v1/namespaces/{EVAL_NS}")  # ignore 404
     cfg = {
         "action_weights": action_weights,
         "alpha": alpha,
-        "dense_strategy": dense_strategy,
+        "dense_source": dense_source,
         "embedding_dim": embedding_dim,
         "seen_items_days": 60,
         "max_results": max(100, args.k),

--- a/sdk/go/redistream/README.md
+++ b/sdk/go/redistream/README.md
@@ -44,7 +44,7 @@ func main() {
         SubjectID: "user-123",
         ObjectID:  "item-a",
         Action:    codohuetypes.ActionView,
-        Timestamp: time.Now().UTC(),
+        OccurredAt: time.Now().UTC(),
     })
 }
 ```


### PR DESCRIPTION
## Summary

  Remediates the security, consistency, retryability, and documentation issues identified during the repository audit.

  ## Changes

  - Prevent cross-namespace recommendation cache collisions with encoded cache keys and cached-response identity validation.
  - Fix same-version catalog re-embedding by invalidating stale item versions and tracking the batch run’s frozen target version.
  - Make namespace and catalog item deletion retryable after partial Redis or Qdrant failures.
  - Coordinate compute, namespace deletion, and application reset through shared/exclusive PostgreSQL advisory locks.
  - Reject events when namespace configuration is missing or unavailable instead of silently applying default weights.
  - Mark batch runs as failed when the dense phase fails while still allowing the independent trending phase to run.
  - Allow valid admin credentials to bypass an exhausted failed-attempt bucket.
  - Apply an 8 MiB hard limit to strict JSON request decoding.
  - Update README examples, the evaluation script, and Redis Streams SDK documentation to use the current API contract.
  - Add an audit report with remediation status.

  ## Behavioral Changes

  - Recommendation cache keys now use the rec:v2:* format. Existing cache entries expire naturally and are no longer read.
  - Event ingest rejects unknown namespaces and retries transient namespace-config lookup failures.
  - Catalog item deletion returns an error when Qdrant cleanup fails, allowing callers to retry safely.
  - A dense-phase failure now results in batch_run_logs.success=false.
  - Correct admin credentials remain usable after failed login attempts from the same proxy IP.

  ## Testing

  - make test
  - make test-race
  - make test-e2e
  - Maintenance-lock E2E test against PostgreSQL
  - make lint
  - make web-admin-lint
  - make web-admin-test
  - make compose-check
  - git diff --check

  ## Migration and Rollout

  - No database migration is required.
  - No new environment variables are required.
  - Deploy the API, admin, cron, and embedder binaries together because the compute maintenance-lock protocol and re-embed watcher contract changed across components.
  - A short-lived recommendation cache miss increase is expected after deployment due to the cache key version change.