### PR TITLE
fix(admin): resolve generation-aware resource names

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,6 +185,10 @@ The table shows generation-1 names. Delete/recreate increments the namespace
 generation; generation 2+ uses `nslifecycle`-qualified Redis and Qdrant names
 (for example `trending:demo:g2` and `demo_g2_objects_dense`). Stream envelopes
 carry `namespace_generation`; stale-generation work is acknowledged and dropped.
+Admin inspection, backlog, TTL, dense-dimension guards, vector previews, and
+catalog-point deletion resolve the same current generation before addressing
+Redis or Qdrant; the dashboard never falls back to generation-1 artifacts for
+an active recreated namespace.
 
 ### 5.3 Qdrant
 

--- a/cmd/admin/catalog_adapter.go
+++ b/cmd/admin/catalog_adapter.go
@@ -46,6 +46,7 @@ func (a *catalogConfigAdapter) GetCatalog(ctx context.Context, ns string) (*admi
 	}
 	return &admin.NamespaceCatalogConfig{
 		Namespace:       cfg.Namespace,
+		Generation:      cfg.Generation,
 		Enabled:         cfg.DenseSource == codohuetypes.DenseSourceCatalog,
 		StrategyID:      cfg.CatalogStrategyID,
 		StrategyVersion: cfg.CatalogStrategyVersion,
@@ -99,6 +100,7 @@ func (a *catalogConfigAdapter) UpdateCatalog(ctx context.Context, ns string, req
 
 	return &admin.NamespaceCatalogConfig{
 		Namespace:       cfg.Namespace,
+		Generation:      cfg.Generation,
 		Enabled:         cfg.DenseSource == codohuetypes.DenseSourceCatalog,
 		StrategyID:      cfg.CatalogStrategyID,
 		StrategyVersion: cfg.CatalogStrategyVersion,

--- a/cmd/admin/catalog_backlog_adapter.go
+++ b/cmd/admin/catalog_backlog_adapter.go
@@ -9,6 +9,7 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/jarviisha/codohue/internal/admin"
+	"github.com/jarviisha/codohue/internal/core/nslifecycle"
 )
 
 // catalogStateCounter is the Postgres-side dependency of the backlog adapter.
@@ -24,17 +25,25 @@ type catalogStateCounter interface {
 // is owned by the catalog/embedder feature, not the admin domain.
 type catalogBacklogAdapter struct {
 	counter catalogStateCounter
-	redis   *goredis.Client
+	redis   catalogBacklogRedis
 }
 
-func newCatalogBacklogAdapter(counter catalogStateCounter, redis *goredis.Client) *catalogBacklogAdapter {
+type catalogBacklogRedis interface {
+	XLen(ctx context.Context, stream string) *goredis.IntCmd
+	XInfoGroups(ctx context.Context, stream string) *goredis.XInfoGroupsCmd
+}
+
+func newCatalogBacklogAdapter(counter catalogStateCounter, redis catalogBacklogRedis) *catalogBacklogAdapter {
 	return &catalogBacklogAdapter{counter: counter, redis: redis}
 }
 
 // Read returns the operational backlog snapshot for one namespace. Redis is
 // optional: when nil or unavailable the stream_len count stays at zero so
 // the admin panel still renders the Postgres-side state breakdown.
-func (a *catalogBacklogAdapter) Read(ctx context.Context, namespace string) (admin.CatalogBacklog, error) {
+func (a *catalogBacklogAdapter) Read(ctx context.Context, namespace string, generation int64) (admin.CatalogBacklog, error) {
+	if generation < 1 {
+		generation = 1
+	}
 	counts, err := a.counter.CountCatalogItemStates(ctx, namespace)
 	if err != nil {
 		return admin.CatalogBacklog{}, fmt.Errorf("count catalog item states: %w", err)
@@ -49,7 +58,7 @@ func (a *catalogBacklogAdapter) Read(ctx context.Context, namespace string) (adm
 	}
 
 	if a.redis != nil {
-		stream := "catalog:embed:" + namespace
+		stream := nslifecycle.MustPhysicalName(nslifecycle.KindEmbedStream, namespace, generation)
 
 		n, err := a.redis.XLen(ctx, stream).Result()
 		switch {

--- a/cmd/admin/catalog_backlog_adapter.go
+++ b/cmd/admin/catalog_backlog_adapter.go
@@ -37,6 +37,17 @@ func newCatalogBacklogAdapter(counter catalogStateCounter, redis catalogBacklogR
 	return &catalogBacklogAdapter{counter: counter, redis: redis}
 }
 
+// backlogRedisClient converts a possibly-nil client into a nil interface
+// value. Assigning a nil *goredis.Client straight into catalogBacklogRedis
+// yields a non-nil interface, which would slip past Read's optional-Redis
+// guard and dereference the nil client.
+func backlogRedisClient(client *goredis.Client) catalogBacklogRedis {
+	if client == nil {
+		return nil
+	}
+	return client
+}
+
 // Read returns the operational backlog snapshot for one namespace. Redis is
 // optional: when nil or unavailable the stream_len count stays at zero so
 // the admin panel still renders the Postgres-side state breakdown.

--- a/cmd/admin/catalog_backlog_adapter_test.go
+++ b/cmd/admin/catalog_backlog_adapter_test.go
@@ -66,6 +66,25 @@ func TestCatalogBacklogAdapter_ReadMapsCountsWithoutRedis(t *testing.T) {
 	}
 }
 
+// The production wiring passes a *goredis.Client that run() nils out when
+// Redis is unreachable. Passing an untyped nil literal, as the other cases
+// do, would not exercise that path.
+func TestCatalogBacklogAdapter_ReadWithUnavailableRedisClient(t *testing.T) {
+	var unavailable *goredis.Client
+	counter := &fakeStateCounter{counts: admin.CatalogItemStateCounts{Pending: 3, DeadLetter: 7}}
+	adapter := newCatalogBacklogAdapter(counter, backlogRedisClient(unavailable))
+
+	got, err := adapter.Read(context.Background(), "ns_a", 1)
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+
+	want := admin.CatalogBacklog{Pending: 3, DeadLetter: 7, StreamLen: 0}
+	if got != want {
+		t.Fatalf("backlog mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
 func TestCatalogBacklogAdapter_ReadPropagatesCounterError(t *testing.T) {
 	wantErr := errors.New("db is down")
 	adapter := newCatalogBacklogAdapter(&fakeStateCounter{err: wantErr}, nil)

--- a/cmd/admin/catalog_backlog_adapter_test.go
+++ b/cmd/admin/catalog_backlog_adapter_test.go
@@ -3,10 +3,31 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/jarviisha/codohue/internal/admin"
 )
+
+type fakeBacklogRedis struct {
+	streams []string
+}
+
+func (f *fakeBacklogRedis) XLen(ctx context.Context, stream string) *goredis.IntCmd {
+	f.streams = append(f.streams, stream)
+	cmd := goredis.NewIntCmd(ctx)
+	cmd.SetVal(0)
+	return cmd
+}
+
+func (f *fakeBacklogRedis) XInfoGroups(ctx context.Context, stream string) *goredis.XInfoGroupsCmd {
+	f.streams = append(f.streams, stream)
+	cmd := goredis.NewXInfoGroupsCmd(ctx, stream)
+	cmd.SetVal(nil)
+	return cmd
+}
 
 type fakeStateCounter struct {
 	counts admin.CatalogItemStateCounts
@@ -31,7 +52,7 @@ func TestCatalogBacklogAdapter_ReadMapsCountsWithoutRedis(t *testing.T) {
 	}
 	adapter := newCatalogBacklogAdapter(counter, nil)
 
-	got, err := adapter.Read(context.Background(), "ns_a")
+	got, err := adapter.Read(context.Background(), "ns_a", 1)
 	if err != nil {
 		t.Fatalf("Read returned error: %v", err)
 	}
@@ -49,8 +70,21 @@ func TestCatalogBacklogAdapter_ReadPropagatesCounterError(t *testing.T) {
 	wantErr := errors.New("db is down")
 	adapter := newCatalogBacklogAdapter(&fakeStateCounter{err: wantErr}, nil)
 
-	_, err := adapter.Read(context.Background(), "ns_a")
+	_, err := adapter.Read(context.Background(), "ns_a", 1)
 	if err == nil || !errors.Is(err, wantErr) {
 		t.Fatalf("expected wrapped %v, got %v", wantErr, err)
+	}
+}
+
+func TestCatalogBacklogAdapter_ReadUsesCurrentGenerationStream(t *testing.T) {
+	redis := &fakeBacklogRedis{}
+	adapter := newCatalogBacklogAdapter(&fakeStateCounter{}, redis)
+
+	if _, err := adapter.Read(context.Background(), "ns_a", 3); err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	want := []string{"catalog:embed:ns_a:g3", "catalog:embed:ns_a:g3"}
+	if fmt.Sprint(redis.streams) != fmt.Sprint(want) {
+		t.Fatalf("streams = %v, want %v", redis.streams, want)
 	}
 }

--- a/cmd/admin/dense_collection_checker.go
+++ b/cmd/admin/dense_collection_checker.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	qdrantpb "github.com/qdrant/go-client/qdrant"
+
+	"github.com/jarviisha/codohue/internal/core/nslifecycle"
 )
 
 // denseCollectionChecker backs nsconfig's embedding_dim change guard.
@@ -17,8 +19,12 @@ type denseCollectionChecker struct {
 
 // DenseCollectionsExist reports whether either dense collection exists for
 // the namespace.
-func (c *denseCollectionChecker) DenseCollectionsExist(ctx context.Context, namespace string) (bool, error) {
-	for _, name := range []string{namespace + "_objects_dense", namespace + "_subjects_dense"} {
+func (c *denseCollectionChecker) DenseCollectionsExist(ctx context.Context, namespace string, generation int64) (bool, error) {
+	if generation < 1 {
+		generation = 1
+	}
+	for _, kind := range []nslifecycle.PhysicalKind{nslifecycle.KindObjectsDense, nslifecycle.KindSubjectsDense} {
+		name := nslifecycle.MustPhysicalName(kind, namespace, generation)
 		exists, err := c.client.CollectionExists(ctx, name)
 		if err != nil {
 			return false, fmt.Errorf("collection exists %s: %w", name, err)

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -172,7 +172,7 @@ func run() error {
 	catalogAdapter := newCatalogConfigAdapter(nsConfigSvc, embedstrategy.DefaultRegistry())
 	svc.SetCatalogConfigurator(catalogAdapter)
 	svc.SetCatalogStrategyPicker(catalogAdapter)
-	svc.SetCatalogBacklogReader(newCatalogBacklogAdapter(repo, redisClient))
+	svc.SetCatalogBacklogReader(newCatalogBacklogAdapter(repo, backlogRedisClient(redisClient)))
 	svc.SetEventRateTracker(eventRate)
 
 	// Session tokens are signed with independent random material — never the

--- a/internal/admin/catalog_ops_service.go
+++ b/internal/admin/catalog_ops_service.go
@@ -223,7 +223,7 @@ func (s *Service) GetCatalogItem(ctx context.Context, namespace string, id int64
 }
 
 func (s *Service) attachCatalogVector(ctx context.Context, item *CatalogItemDetail) {
-	if s.qdrantClient == nil {
+	if s.qdrantReader == nil {
 		return
 	}
 	numericID, ok, err := s.repo.LookupNumericObjectID(ctx, item.Namespace, item.ObjectID)
@@ -238,8 +238,17 @@ func (s *Service) attachCatalogVector(ctx context.Context, item *CatalogItemDeta
 		return
 	}
 
-	collection := item.Namespace + "_objects_dense"
-	results, err := s.qdrantClient.Get(ctx, &qdrant.GetPoints{
+	generation, generationErr := s.namespaceGeneration(ctx, item.Namespace)
+	if generationErr != nil {
+		slog.WarnContext(ctx, "catalog item generation lookup failed",
+			slog.String("namespace", item.Namespace),
+			slog.String("object_id", item.ObjectID),
+			slog.String("error", generationErr.Error()),
+		)
+		return
+	}
+	collection := nslifecycle.MustPhysicalName(nslifecycle.KindObjectsDense, item.Namespace, generation)
+	results, err := s.qdrantReader.Get(ctx, &qdrant.GetPoints{
 		CollectionName: collection,
 		Ids:            []*qdrant.PointId{qdrant.NewIDNum(numericID)},
 		WithVectors:    qdrant.NewWithVectorsInclude("dense_interactions"),
@@ -356,6 +365,20 @@ func (s *Service) BulkRedriveDeadletter(ctx context.Context, namespace string) (
 // the catalog row. Keeping the durable row until external cleanup succeeds
 // makes a transient Qdrant failure retryable.
 func (s *Service) DeleteCatalogItem(ctx context.Context, namespace string, id int64) error {
+	if s.lifecycle != nil && nslifecycle.RequireNamespaceLease(ctx, namespace) != nil {
+		return s.lifecycle.WithWriter(ctx, namespace, func(leased context.Context, current *nslifecycle.NamespaceLifecycle) error {
+			return s.deleteCatalogItemGeneration(leased, namespace, current.Generation, id)
+		})
+	}
+	generation, err := s.namespaceGeneration(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	return s.deleteCatalogItemGeneration(ctx, namespace, generation, id)
+}
+
+func (s *Service) deleteCatalogItemGeneration(ctx context.Context, namespace string, generation, id int64) error {
+	generation = normalizeGeneration(generation)
 	item, err := s.repo.GetCatalogItem(ctx, namespace, id)
 	if err != nil {
 		return fmt.Errorf("get catalog item for delete: %w", err)
@@ -370,7 +393,8 @@ func (s *Service) DeleteCatalogItem(ctx context.Context, namespace string, id in
 			return fmt.Errorf("lookup numeric object id: %w", lookupErr)
 		}
 		if ok {
-			if deleteErr := s.qdrantDeleter.DeletePoint(ctx, namespace+"_objects_dense", numID); deleteErr != nil {
+			collection := nslifecycle.MustPhysicalName(nslifecycle.KindObjectsDense, namespace, generation)
+			if deleteErr := s.qdrantDeleter.DeletePoint(ctx, collection, numID); deleteErr != nil {
 				return fmt.Errorf("delete qdrant point: %w", deleteErr)
 			}
 		}

--- a/internal/admin/catalog_ops_service_test.go
+++ b/internal/admin/catalog_ops_service_test.go
@@ -390,6 +390,7 @@ func TestBulkRedriveDeadletter_Service_EmptyOK(t *testing.T) {
 
 func TestDeleteCatalogItem_Service_HappyPath(t *testing.T) {
 	repo := &fakeRepo{
+		namespace:               &NamespaceConfig{Namespace: "ns", Generation: 2},
 		getCatalogItem:          &CatalogItemDetail{CatalogItemSummary: CatalogItemSummary{ID: 7, ObjectID: "o7"}, Namespace: "ns"},
 		deleteCatalogItemFound:  true,
 		deleteCatalogItemObject: "o7",
@@ -407,8 +408,27 @@ func TestDeleteCatalogItem_Service_HappyPath(t *testing.T) {
 	if len(del.calls) != 1 {
 		t.Fatalf("expected 1 qdrant delete call, got %d", len(del.calls))
 	}
-	if del.calls[0].collection != "ns_objects_dense" || del.calls[0].id != 123 {
+	if del.calls[0].collection != "ns_g2_objects_dense" || del.calls[0].id != 123 {
 		t.Errorf("unexpected qdrant call: %+v", del.calls[0])
+	}
+}
+
+func TestGetCatalogItem_UsesCurrentGenerationCollection(t *testing.T) {
+	repo := &fakeRepo{
+		namespace:          &NamespaceConfig{Namespace: "ns", Generation: 4},
+		getCatalogItem:     &CatalogItemDetail{CatalogItemSummary: CatalogItemSummary{ID: 7, ObjectID: "o7"}, Namespace: "ns"},
+		numericObjectID:    123,
+		numericObjectFound: true,
+	}
+	reader := &fakeQdrantReader{}
+	svc, _, _ := withCatalogPlumbing(t, repo, nil)
+	svc.qdrantReader = reader
+
+	if _, err := svc.GetCatalogItem(context.Background(), "ns", 7); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reader.calls) != 1 || reader.calls[0].CollectionName != "ns_g4_objects_dense" {
+		t.Fatalf("qdrant reads = %+v, want ns_g4_objects_dense", reader.calls)
 	}
 }
 
@@ -452,6 +472,25 @@ func TestDeleteCatalogItem_Service_QdrantFailureIsRetryable(t *testing.T) {
 	}
 	if repo.deleteCatalogItemCalled != 0 {
 		t.Fatal("postgres row must remain until qdrant cleanup succeeds")
+	}
+}
+
+func TestDeleteCatalogItem_ServiceUsesLeasedGeneration(t *testing.T) {
+	repo := &fakeRepo{
+		getCatalogItem:          &CatalogItemDetail{CatalogItemSummary: CatalogItemSummary{ID: 7, ObjectID: "o7"}, Namespace: "ns"},
+		deleteCatalogItemFound:  true,
+		deleteCatalogItemObject: "o7",
+		numericObjectID:         99,
+		numericObjectFound:      true,
+	}
+	svc, _, del := withCatalogPlumbing(t, repo, nil)
+	svc.SetLifecycleCoordinator(newFakeLifecycle("ns", 5))
+
+	if err := svc.DeleteCatalogItem(context.Background(), "ns", 7); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(del.calls) != 1 || del.calls[0].collection != "ns_g5_objects_dense" {
+		t.Fatalf("qdrant deletes = %+v, want ns_g5_objects_dense", del.calls)
 	}
 }
 

--- a/internal/admin/dashboard_service.go
+++ b/internal/admin/dashboard_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jarviisha/codohue/internal/core/batchrun"
+	"github.com/jarviisha/codohue/internal/core/nslifecycle"
 	"github.com/jarviisha/codohue/pkg/codohuetypes"
 )
 
@@ -53,7 +54,7 @@ func (s *Service) GetOverview(ctx context.Context) (*OverviewResponse, error) {
 		if row.Catalog.Enabled && s.catalogBacklog != nil {
 			// Best-effort: a failed read leaves zeros rather than sinking the
 			// whole fleet page, but it is logged so a persistent failure shows.
-			if backlog, blErr := s.catalogBacklog.Read(ctx, ns.Namespace); blErr == nil {
+			if backlog, blErr := s.catalogBacklog.Read(ctx, ns.Namespace, ns.Generation); blErr == nil {
 				row.Catalog.Pending = backlog.Pending
 				row.Catalog.DeadLetter = backlog.DeadLetter
 			} else {
@@ -110,10 +111,7 @@ func (s *Service) GetNamespaceDashboard(ctx context.Context, namespace string) (
 		return nil, fmt.Errorf("get event counts: %w", err)
 	}
 
-	qdrant, err := s.GetQdrant(ctx, namespace)
-	if err != nil {
-		return nil, fmt.Errorf("get qdrant: %w", err)
-	}
+	qdrant := s.getQdrantGeneration(ctx, namespace, cfg.Generation)
 
 	// Attribution coverage drives the exclude_authored hint on the config
 	// page. A failure here must not sink the whole dashboard — the operator
@@ -130,11 +128,11 @@ func (s *Service) GetNamespaceDashboard(ctx context.Context, namespace string) (
 		GeneratedAt:     now.UTC(),
 		Config:          *cfg,
 		LastRuns:        lastRuns,
-		Catalog:         s.namespaceBacklog(ctx, namespace),
+		Catalog:         s.namespaceBacklog(ctx, namespace, cfg.Generation),
 		Events24h:       eventCounts[namespace],
 		EventsPerMinNow: s.eventsPerMin(namespace),
 		Qdrant:          *qdrant,
-		TrendingTTLSec:  s.trendingTTLSec(ctx, namespace),
+		TrendingTTLSec:  s.trendingTTLSec(ctx, namespace, cfg.Generation),
 		AuthorCoverage:  AuthorCoverage{Attributed: attributed, Total: totalItems},
 	}, nil
 }
@@ -216,7 +214,12 @@ func (s *Service) denseDowngradeAlerts(ctx context.Context, namespaces []Namespa
 		if !hybridConfigured {
 			continue
 		}
-		stat := s.collectionStatsFn(ctx, ns.Namespace+"_subjects_dense")
+		generation := ns.Generation
+		if generation < 1 {
+			generation = 1
+		}
+		collection := nslifecycle.MustPhysicalName(nslifecycle.KindSubjectsDense, ns.Namespace, generation)
+		stat := s.collectionStatsFn(ctx, collection)
 		if stat.Exists && stat.PointsCount > 0 {
 			continue
 		}
@@ -296,11 +299,11 @@ func (s *Service) embedderHeartbeat(ctx context.Context) EmbedderHeartbeat {
 // namespaceBacklog reads the live catalog backlog for the dashboard. Failures
 // (or no reader wired) degrade to zero counts, logged so a persistent
 // failure stays visible.
-func (s *Service) namespaceBacklog(ctx context.Context, namespace string) CatalogBacklog {
+func (s *Service) namespaceBacklog(ctx context.Context, namespace string, generation int64) CatalogBacklog {
 	if s.catalogBacklog == nil {
 		return CatalogBacklog{}
 	}
-	backlog, err := s.catalogBacklog.Read(ctx, namespace)
+	backlog, err := s.catalogBacklog.Read(ctx, namespace, normalizeGeneration(generation))
 	if err != nil {
 		slog.WarnContext(ctx, "dashboard: catalog backlog read failed",
 			slog.String("namespace", namespace), slog.String("error", err.Error()))
@@ -311,11 +314,12 @@ func (s *Service) namespaceBacklog(ctx context.Context, namespace string) Catalo
 
 // trendingTTLSec probes the remaining TTL of the namespace's trending ZSET.
 // Redis TTL semantics carry through: -2 = key missing, -1 = no expiry.
-func (s *Service) trendingTTLSec(ctx context.Context, namespace string) int {
+func (s *Service) trendingTTLSec(ctx context.Context, namespace string, generation int64) int {
 	if s.redisClient == nil {
 		return -2
 	}
-	d, err := s.redisClient.TTL(ctx, "trending:"+namespace).Result()
+	key := nslifecycle.MustPhysicalName(nslifecycle.KindTrending, namespace, normalizeGeneration(generation))
+	d, err := s.redisClient.TTL(ctx, key).Result()
 	if err != nil {
 		return -2
 	}

--- a/internal/admin/dashboard_service_test.go
+++ b/internal/admin/dashboard_service_test.go
@@ -180,8 +180,8 @@ func TestGetOverview_EmbedderHeartbeatNotFakedWhenUnknown(t *testing.T) {
 
 func TestDenseDowngradeAlerts(t *testing.T) {
 	counts := map[string]uint64{
-		"hybrid-empty_subjects_dense": 0,
-		"hybrid-ok_subjects_dense":    42,
+		"hybrid-empty_g2_subjects_dense": 0,
+		"hybrid-ok_subjects_dense":       42,
 	}
 	s := &Service{collectionStatsFn: func(_ context.Context, name string) QdrantCollection {
 		n, ok := counts[name]
@@ -189,11 +189,11 @@ func TestDenseDowngradeAlerts(t *testing.T) {
 	}}
 
 	namespaces := []NamespaceConfig{
-		{Namespace: "hybrid-empty", Alpha: 0.5, DenseSource: "byoe"},     // configured hybrid, no vectors → alert
-		{Namespace: "hybrid-ok", Alpha: 0.5, DenseSource: "catalog"},     // healthy → no alert
-		{Namespace: "sparse-only", Alpha: 1.0, DenseSource: "byoe"},      // alpha leaves no dense weight → no alert
-		{Namespace: "dense-off", Alpha: 0.5, DenseSource: "disabled"},    // dense off → no alert
-		{Namespace: "missing-coll", Alpha: 0.3, DenseSource: "item2vec"}, // collection absent entirely → alert
+		{Namespace: "hybrid-empty", Generation: 2, Alpha: 0.5, DenseSource: "byoe"}, // configured hybrid, no vectors → alert
+		{Namespace: "hybrid-ok", Alpha: 0.5, DenseSource: "catalog"},                // healthy → no alert
+		{Namespace: "sparse-only", Alpha: 1.0, DenseSource: "byoe"},                 // alpha leaves no dense weight → no alert
+		{Namespace: "dense-off", Alpha: 0.5, DenseSource: "disabled"},               // dense off → no alert
+		{Namespace: "missing-coll", Alpha: 0.3, DenseSource: "item2vec"},            // collection absent entirely → alert
 	}
 
 	alerts := s.denseDowngradeAlerts(context.Background(), namespaces)

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -97,7 +97,7 @@ type nsCatalogConfigurator interface {
 // namespace by querying both Postgres (catalog_items state buckets) and
 // Redis (XLEN of catalog:embed:{ns}). Wired by an adapter in cmd/admin.
 type catalogBacklogReader interface {
-	Read(ctx context.Context, namespace string) (CatalogBacklog, error)
+	Read(ctx context.Context, namespace string, generation int64) (CatalogBacklog, error)
 }
 
 // eventRateReader exposes the admin-plane per-namespace ingest rate, fed by
@@ -159,6 +159,10 @@ type qdrantPointDeleter interface {
 	DeletePoint(ctx context.Context, collection string, numericID uint64) error
 }
 
+type qdrantPointReader interface {
+	Get(ctx context.Context, points *qdrant.GetPoints) ([]*qdrant.RetrievedPoint, error)
+}
+
 // Service implements admin business logic.
 type Service struct {
 	repo            adminRepo
@@ -174,6 +178,7 @@ type Service struct {
 	catalogPicker   catalogStrategyPicker
 	streamPublisher streamPublisher
 	qdrantDeleter   qdrantPointDeleter
+	qdrantReader    qdrantPointReader
 	eventRate       eventRateReader
 	lifecycle       lifecycleCoordinator
 	nowFn           func() time.Time
@@ -209,6 +214,7 @@ func NewService(repo adminRepo, apiURL, apiKey string, redisClient *goredis.Clie
 	}
 	if qdrantClient != nil {
 		s.qdrantDeleter = newQdrantClientPointDeleter(qdrantClient)
+		s.qdrantReader = qdrantClient
 	}
 	s.collectionStatsFn = s.qdrantCollection
 	return s
@@ -361,7 +367,7 @@ func (s *Service) GetCatalogConfig(ctx context.Context, namespace string) (*Name
 	if s.catalogBacklog != nil {
 		// Backlog read failures are non-fatal; surface zero counts so the admin
 		// UI still renders, but log so a persistent failure stays visible.
-		if backlog, err := s.catalogBacklog.Read(ctx, namespace); err == nil {
+		if backlog, err := s.catalogBacklog.Read(ctx, namespace, cfg.Generation); err == nil {
 			resp.Backlog = backlog
 		} else {
 			slog.WarnContext(ctx, "catalog backlog read failed",
@@ -532,12 +538,43 @@ func (s *Service) GetSubjectRecommendations(ctx context.Context, namespace, subj
 
 // GetQdrant returns point counts for the four Qdrant collections of a namespace.
 func (s *Service) GetQdrant(ctx context.Context, namespace string) (*QdrantInspectResponse, error) {
+	generation, err := s.namespaceGeneration(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return s.getQdrantGeneration(ctx, namespace, generation), nil
+}
+
+func (s *Service) getQdrantGeneration(ctx context.Context, namespace string, generation int64) *QdrantInspectResponse {
+	generation = normalizeGeneration(generation)
+	stats := s.collectionStatsFn
+	if stats == nil {
+		stats = s.qdrantCollection
+	}
 	return &QdrantInspectResponse{
-		Subjects:      s.qdrantCollection(ctx, namespace+"_subjects"),
-		Objects:       s.qdrantCollection(ctx, namespace+"_objects"),
-		SubjectsDense: s.qdrantCollection(ctx, namespace+"_subjects_dense"),
-		ObjectsDense:  s.qdrantCollection(ctx, namespace+"_objects_dense"),
-	}, nil
+		Subjects:      stats(ctx, nslifecycle.MustPhysicalName(nslifecycle.KindSubjects, namespace, generation)),
+		Objects:       stats(ctx, nslifecycle.MustPhysicalName(nslifecycle.KindObjects, namespace, generation)),
+		SubjectsDense: stats(ctx, nslifecycle.MustPhysicalName(nslifecycle.KindSubjectsDense, namespace, generation)),
+		ObjectsDense:  stats(ctx, nslifecycle.MustPhysicalName(nslifecycle.KindObjectsDense, namespace, generation)),
+	}
+}
+
+func (s *Service) namespaceGeneration(ctx context.Context, namespace string) (int64, error) {
+	cfg, err := s.repo.GetNamespace(ctx, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("get namespace generation: %w", err)
+	}
+	if cfg == nil || cfg.Generation < 1 {
+		return 1, nil
+	}
+	return cfg.Generation, nil
+}
+
+func normalizeGeneration(generation int64) int64 {
+	if generation < 1 {
+		return 1
+	}
+	return generation
 }
 
 func (s *Service) qdrantCollection(ctx context.Context, name string) QdrantCollection {
@@ -572,7 +609,7 @@ func (s *Service) recommendDebug(ctx context.Context, namespace, subjectID strin
 	debug.InteractionCount = stats.InteractionCount
 	debug.SeenItemsCount = len(stats.SeenItems)
 	if stats.NumericID != nil {
-		debug.SparseNNZ = s.sparseNNZ(ctx, namespace, *stats.NumericID)
+		debug.SparseNNZ = s.sparseNNZ(ctx, namespace, ns.Generation, *stats.NumericID)
 	}
 	return debug
 }
@@ -625,7 +662,11 @@ func (s *Service) GetSubjectProfile(ctx context.Context, namespace, subjectID st
 
 	nnz := -1
 	if stats.NumericID != nil {
-		nnz = s.sparseNNZ(ctx, namespace, *stats.NumericID)
+		generation := int64(1)
+		if ns != nil && ns.Generation > 0 {
+			generation = ns.Generation
+		}
+		nnz = s.sparseNNZ(ctx, namespace, generation, *stats.NumericID)
 	}
 
 	seenItems := stats.SeenItems
@@ -643,12 +684,12 @@ func (s *Service) GetSubjectProfile(ctx context.Context, namespace, subjectID st
 	}, nil
 }
 
-func (s *Service) sparseNNZ(ctx context.Context, namespace string, numericID uint64) int {
-	if s.qdrantClient == nil {
+func (s *Service) sparseNNZ(ctx context.Context, namespace string, generation int64, numericID uint64) int {
+	if s.qdrantReader == nil {
 		return -1
 	}
-	results, err := s.qdrantClient.Get(ctx, &qdrant.GetPoints{
-		CollectionName: namespace + "_subjects",
+	results, err := s.qdrantReader.Get(ctx, &qdrant.GetPoints{
+		CollectionName: nslifecycle.MustPhysicalName(nslifecycle.KindSubjects, namespace, normalizeGeneration(generation)),
 		Ids:            []*qdrant.PointId{qdrant.NewIDNum(numericID)},
 		WithVectors:    qdrant.NewWithVectorsInclude("sparse_interactions"),
 	})
@@ -664,6 +705,10 @@ func (s *Service) sparseNNZ(ctx context.Context, namespace string, numericID uin
 
 // GetTrending proxies the trending request to cmd/api, then fetches the Redis TTL.
 func (s *Service) GetTrending(ctx context.Context, namespace string, limit, offset, windowHours int) (*TrendingAdminResponse, error) {
+	generation, err := s.namespaceGeneration(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
 	params := fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
 	if windowHours > 0 {
 		params += "&window_hours=" + strconv.Itoa(windowHours)
@@ -708,7 +753,8 @@ func (s *Service) GetTrending(ctx context.Context, namespace string, limit, offs
 	// time.Duration(-2)*time.Second gives int(d)==-2000000000 (nanoseconds), not -2.
 	ttl := -2
 	if s.redisClient != nil {
-		d, err := s.redisClient.TTL(ctx, "trending:"+namespace).Result()
+		key := nslifecycle.MustPhysicalName(nslifecycle.KindTrending, namespace, generation)
+		d, err := s.redisClient.TTL(ctx, key).Result()
 		if err == nil {
 			ttl = int(d.Seconds())
 		}

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/qdrant/go-client/qdrant"
 	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/jarviisha/codohue/internal/core/batchrun"
@@ -340,6 +341,15 @@ type fakeQdrantDeleter struct {
 		id         uint64
 	}
 	err error
+}
+
+type fakeQdrantReader struct {
+	calls []*qdrant.GetPoints
+}
+
+func (f *fakeQdrantReader) Get(_ context.Context, points *qdrant.GetPoints) ([]*qdrant.RetrievedPoint, error) {
+	f.calls = append(f.calls, points)
+	return nil, nil
 }
 
 func (f *fakeQdrantDeleter) DeletePoint(_ context.Context, collection string, id uint64) error {
@@ -687,6 +697,43 @@ func TestGetSubjectProfile_NoQdrant(t *testing.T) {
 	}
 	if profile.SeenItemsDays != 30 {
 		t.Errorf("expected seen_items_days=30, got %d", profile.SeenItemsDays)
+	}
+}
+
+func TestGetSubjectProfile_UsesCurrentGenerationCollection(t *testing.T) {
+	numID := uint64(42)
+	repo := &fakeRepo{
+		namespace: &NamespaceConfig{Namespace: "ns1", Generation: 3, SeenItemsDays: 30},
+		subjectStats: &SubjectStats{
+			NumericID: &numID,
+		},
+	}
+	reader := &fakeQdrantReader{}
+	svc := newTestService(repo, "", "")
+	svc.qdrantReader = reader
+
+	if _, err := svc.GetSubjectProfile(context.Background(), "ns1", "user-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reader.calls) != 1 || reader.calls[0].CollectionName != "ns1_g3_subjects" {
+		t.Fatalf("qdrant reads = %+v, want ns1_g3_subjects", reader.calls)
+	}
+}
+
+func TestGetQdrant_UsesCurrentGenerationCollections(t *testing.T) {
+	svc := newTestService(&fakeRepo{namespace: &NamespaceConfig{Namespace: "ns1", Generation: 2}}, "", "")
+	var names []string
+	svc.collectionStatsFn = func(_ context.Context, name string) QdrantCollection {
+		names = append(names, name)
+		return QdrantCollection{}
+	}
+
+	if _, err := svc.GetQdrant(context.Background(), "ns1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"ns1_g2_subjects", "ns1_g2_objects", "ns1_g2_subjects_dense", "ns1_g2_objects_dense"}
+	if fmt.Sprint(names) != fmt.Sprint(want) {
+		t.Fatalf("collections = %v, want %v", names, want)
 	}
 }
 

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -39,6 +39,7 @@ type NamespaceConfig struct {
 // NamespaceCatalogConfig is the per-namespace catalog auto-embedding state.
 type NamespaceCatalogConfig struct {
 	Namespace       string         `json:"namespace"`
+	Generation      int64          `json:"-"`
 	Enabled         bool           `json:"enabled"`
 	StrategyID      string         `json:"strategy_id,omitempty"`
 	StrategyVersion string         `json:"strategy_version,omitempty"`

--- a/internal/nsconfig/service.go
+++ b/internal/nsconfig/service.go
@@ -55,7 +55,7 @@ type Service struct {
 // collections already exist. Defined here (implemented at the wiring layer)
 // so nsconfig never grows a Qdrant dependency.
 type DenseCollectionChecker interface {
-	DenseCollectionsExist(ctx context.Context, namespace string) (bool, error)
+	DenseCollectionsExist(ctx context.Context, namespace string, generation int64) (bool, error)
 }
 
 // SetDenseCollectionChecker wires the embedding_dim change guard. Safe to
@@ -254,7 +254,7 @@ func (s *Service) guardEmbeddingDimChange(ctx context.Context, ns string, req *U
 	if current == nil || current.EmbeddingDim == *req.EmbeddingDim {
 		return nil // new namespace, or a no-op change
 	}
-	exists, err := s.denseCollections.DenseCollectionsExist(ctx, ns)
+	exists, err := s.denseCollections.DenseCollectionsExist(ctx, ns, current.Generation)
 	if err != nil {
 		return fmt.Errorf("check dense collections: %w", err)
 	}

--- a/internal/nsconfig/validate_test.go
+++ b/internal/nsconfig/validate_test.go
@@ -69,25 +69,31 @@ func TestValidateUpsert_CatalogViaUpsertRejected(t *testing.T) {
 }
 
 type fakeDenseChecker struct {
-	exists bool
-	err    error
-	calls  int
+	exists     bool
+	err        error
+	calls      int
+	generation int64
 }
 
-func (f *fakeDenseChecker) DenseCollectionsExist(_ context.Context, _ string) (bool, error) {
+func (f *fakeDenseChecker) DenseCollectionsExist(_ context.Context, _ string, generation int64) (bool, error) {
 	f.calls++
+	f.generation = generation
 	return f.exists, f.err
 }
 
 func TestUpsert_EmbeddingDimChangeLockedWhileCollectionsExist(t *testing.T) {
-	repo := &fakeRepo{getCfg: &namespace.Config{Namespace: "ns", EmbeddingDim: 64}}
+	repo := &fakeRepo{getCfg: &namespace.Config{Namespace: "ns", Generation: 3, EmbeddingDim: 64}}
 	svc := NewService(nil)
 	svc.repo = repo
-	svc.SetDenseCollectionChecker(&fakeDenseChecker{exists: true})
+	checker := &fakeDenseChecker{exists: true}
+	svc.SetDenseCollectionChecker(checker)
 
 	_, err := svc.Upsert(context.Background(), "ns", &UpsertRequest{EmbeddingDim: iptr(128)})
 	if !errors.Is(err, ErrEmbeddingDimLocked) {
 		t.Fatalf("expected ErrEmbeddingDimLocked, got %v — a changed dim fails every dense upsert forever", err)
+	}
+	if checker.generation != 3 {
+		t.Fatalf("dense collection generation = %d, want 3", checker.generation)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve current namespace generation before admin Redis and Qdrant reads
- fence catalog item deletion with the namespace writer lease
- make backlog and dense-dimension checks generation-aware
- add generation-2 regression coverage and architecture documentation

## Validation

- `make test`
- `make test-race`
- `make test-e2e`
- `make compose-check`

Closes #17

