### PR TITLE
fix(recommend): zero fallback recommendation scores

### DIFF
--- a/internal/recommend/service.go
+++ b/internal/recommend/service.go
@@ -930,7 +930,7 @@ func (s *Service) fallbackTrending(ctx context.Context, req *Request, limit int,
 	for i, e := range entries {
 		items[i] = RecommendedItem{
 			ObjectID: e.ObjectID,
-			Score:    e.Score,
+			Score:    0,
 			Rank:     req.Offset + i + 1,
 		}
 	}

--- a/internal/recommend/service_test.go
+++ b/internal/recommend/service_test.go
@@ -283,6 +283,11 @@ func TestDoRecommend_ColdStart_UsesTrendingCache(t *testing.T) {
 	if len(resp.Items) != 2 || resp.Items[0].ObjectID != "trending-1" {
 		t.Errorf("items: got %v", resp.Items)
 	}
+	for _, item := range resp.Items {
+		if item.Score != 0 {
+			t.Errorf("fallback item %q score = %v, want 0", item.ObjectID, item.Score)
+		}
+	}
 }
 
 // ─── doRecommend: CF (count>=5) falls back to popular when no subject vector ─


### PR DESCRIPTION
## Summary

- return zero scores from trending-backed recommendation fallbacks
- preserve raw Redis scores on the dedicated trending endpoint
- add regression coverage for the public recommendation contract

## Validation

- `go test ./internal/recommend`
- full `make test`, `make test-race`, and `make test-e2e` on the combined remediation tree

Closes #23

