### PR TITLE
refactor(redis): centralize stream consumer mechanics

### DIFF
--- a/internal/embedder/worker.go
+++ b/internal/embedder/worker.go
@@ -2,10 +2,8 @@ package embedder
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +12,7 @@ import (
 	"github.com/jarviisha/codohue/internal/core/namespace"
 	"github.com/jarviisha/codohue/internal/core/nslifecycle"
 	"github.com/jarviisha/codohue/internal/infra/metrics"
+	infraredis "github.com/jarviisha/codohue/internal/infra/redis"
 )
 
 // Default worker tunables. Operators can override via cmd/embedder env vars.
@@ -192,14 +191,10 @@ func (w *Worker) refreshNamespaces(ctx context.Context) error {
 		}
 		nsCtx, cancel := context.WithCancel(ctx)
 		w.cancels[key] = cancel
-		w.wg.Add(2)
+		w.wg.Add(1)
 		go func(ns, stream string) {
 			defer w.wg.Done()
 			w.consumePhysicalStream(nsCtx, ns, stream)
-		}(target.namespace, target.stream)
-		go func(ns, stream string) {
-			defer w.wg.Done()
-			w.reapStream(nsCtx, ns, stream)
 		}(target.namespace, target.stream)
 	}
 
@@ -242,76 +237,7 @@ func (w *Worker) consumePhysicalStream(ctx context.Context, ns, stream string) {
 	}
 
 	slog.InfoContext(ctx, "embedder consuming", slog.String("namespace", ns), slog.String("stream", stream))
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		streams, err := w.redis.XReadGroup(ctx, &redis.XReadGroupArgs{
-			Group:    group,
-			Consumer: w.cfg.ConsumerName,
-			Streams:  []string{stream, ">"},
-			Count:    int64(w.cfg.ReadBatchSize),
-			Block:    w.cfg.ReadBlockTime,
-		}).Result()
-
-		if errors.Is(err, redis.Nil) {
-			continue
-		}
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return
-			}
-			// NOGROUP means the stream or group vanished after this consumer
-			// started (namespace deleted + recreated, Redis restarted without
-			// persistence). Re-create instead of retrying into the same error
-			// until the process restarts.
-			if strings.Contains(err.Error(), "NOGROUP") {
-				if egErr := w.ensureGroup(ctx, stream, group); egErr != nil {
-					slog.WarnContext(ctx, "recreate consumer group failed",
-						slog.String("namespace", ns), slog.String("error", egErr.Error()))
-				}
-			}
-			slog.WarnContext(ctx, "xreadgroup failed", slog.String("namespace", ns), slog.String("error", err.Error()))
-			// Brief back-off so we don't hot-loop on persistent errors.
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-
-		for _, s := range streams {
-			for _, msg := range s.Messages {
-				w.handleMessage(ctx, ns, stream, group, msg)
-			}
-		}
-	}
-}
-
-// reapStream periodically reclaims entries idle in another consumer's PEL
-// and re-processes them. This is how a crashed replica's pending work
-// gets re-driven.
-func (w *Worker) reapStream(ctx context.Context, ns, stream string) {
-	// The cursor lives here, per goroutine — one per (namespace, generation)
-	// stream — so a recreated namespace scans its own PEL independently of the
-	// generation it replaced.
-	cursor := "0-0"
-	ticker := time.NewTicker(w.cfg.ReapInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		cursor = w.reapOnce(ctx, ns, stream, cursor)
-	}
+	w.streamConsumer(ns, stream).Run(ctx)
 }
 
 // reapOnce runs one bounded XAUTOCLAIM scan and returns the cursor the next
@@ -324,43 +250,45 @@ func (w *Worker) reapStream(ctx context.Context, ns, stream string) {
 // recreated, so any cursor into the old PEL is meaningless); an error retains
 // it, because a failed call says nothing about how far the scan had got.
 func (w *Worker) reapOnce(ctx context.Context, ns, stream, cursor string) string {
-	group := defaultConsumerGroup
-	if cursor == "" {
-		cursor = "0-0"
-	}
-	for page := 0; page < defaultReapPageBudget; page++ {
-		msgs, next, err := w.redis.XAutoClaim(ctx, &redis.XAutoClaimArgs{
-			Stream: stream, Group: group, Consumer: w.cfg.ConsumerName,
-			MinIdle: w.cfg.MinIdleReap, Start: cursor, Count: int64(w.cfg.ReapBatchSize),
-		}).Result()
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return cursor
-			}
-			if strings.Contains(err.Error(), "NOGROUP") {
-				metrics.StreamReclaimCyclesTotal.WithLabelValues("embed", ns, "nogroup").Inc()
-				return "0-0"
-			}
+	return w.streamConsumer(ns, stream).ReapOnce(ctx, cursor)
+}
+
+func (w *Worker) streamConsumer(ns, stream string) *infraredis.StreamConsumer {
+	return infraredis.NewStreamConsumer(infraredis.StreamConsumerConfig{
+		Stream: stream, Group: defaultConsumerGroup, Consumer: w.cfg.ConsumerName,
+		ReadCount: int64(w.cfg.ReadBatchSize), ReadBlock: w.cfg.ReadBlockTime,
+		ReapInterval: w.cfg.ReapInterval, MinIdleReap: w.cfg.MinIdleReap,
+		ReapCount: int64(w.cfg.ReapBatchSize), ReapPageBudget: defaultReapPageBudget,
+		ReadBackoffMin: time.Second, ReadBackoffMax: time.Second,
+	}, infraredis.StreamConsumerFuncs{
+		CreateGroup: func(ctx context.Context, stream, group, start string) error {
+			return w.redis.XGroupCreateMkStream(ctx, stream, group, start).Err()
+		},
+		ReadGroup: func(ctx context.Context, args *redis.XReadGroupArgs) ([]redis.XStream, error) {
+			return w.redis.XReadGroup(ctx, args).Result()
+		},
+		AutoClaim: func(ctx context.Context, args *redis.XAutoClaimArgs) ([]redis.XMessage, string, error) {
+			return w.redis.XAutoClaim(ctx, args).Result()
+		},
+	}, func(ctx context.Context, msg redis.XMessage) {
+		w.handleMessage(ctx, ns, stream, defaultConsumerGroup, msg)
+	}, infraredis.StreamConsumerObserver{
+		ReadError: func(ctx context.Context, err error) {
+			slog.WarnContext(ctx, "xreadgroup failed", slog.String("namespace", ns), slog.String("error", err.Error()))
+		},
+		RecreateError: func(ctx context.Context, err error) {
+			slog.WarnContext(ctx, "recreate consumer group failed", slog.String("namespace", ns), slog.String("error", err.Error()))
+		},
+		ReclaimError: func(ctx context.Context, err error) {
 			slog.WarnContext(ctx, "xautoclaim failed", slog.String("namespace", ns), slog.String("error", err.Error()))
-			metrics.StreamReclaimCyclesTotal.WithLabelValues("embed", ns, "error").Inc()
-			return cursor
-		}
-		if len(msgs) > 0 {
-			metrics.StreamReclaimedTotal.WithLabelValues("embed", ns).Add(float64(len(msgs)))
-		}
-		for _, msg := range msgs {
-			w.handleMessage(ctx, ns, stream, group, msg)
-		}
-		cursor = next
-		if next == "0-0" || next == "" {
-			metrics.StreamReclaimCyclesTotal.WithLabelValues("embed", ns, "terminal").Inc()
-			return "0-0"
-		}
-	}
-	// The cursor survives the tick, so this is a paced scan rather than a
-	// stall — but it is the only signal that the PEL is deeper than one tick.
-	metrics.StreamReclaimCyclesTotal.WithLabelValues("embed", ns, "budget_exhausted").Inc()
-	return cursor
+		},
+		Reclaimed: func(count int) {
+			metrics.StreamReclaimedTotal.WithLabelValues("embed", ns).Add(float64(count))
+		},
+		ReclaimCompleted: func(outcome infraredis.ReclaimOutcome) {
+			metrics.StreamReclaimCyclesTotal.WithLabelValues("embed", ns, string(outcome)).Inc()
+		},
+	})
 }
 
 // handleMessage decodes a stream entry, dispatches it through the service,
@@ -426,7 +354,7 @@ func (w *Worker) ensureGroup(ctx context.Context, stream, group string) error {
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(err.Error(), "BUSYGROUP") {
+	if infraredis.IsBusyGroupError(err) {
 		return nil
 	}
 	return fmt.Errorf("xgroup create %s/%s: %w", stream, group, err)

--- a/internal/infra/redis/docs.go
+++ b/internal/infra/redis/docs.go
@@ -1,2 +1,2 @@
-// Package redis provides a go-redis client used for consuming events from Redis Streams.
+// Package redis provides Redis clients and shared stream-consumer mechanics.
 package redis

--- a/internal/infra/redis/stream_consumer.go
+++ b/internal/infra/redis/stream_consumer.go
@@ -1,0 +1,225 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const initialReclaimCursor = "0-0"
+
+// ReclaimOutcome describes why a bounded pending-entry scan stopped.
+type ReclaimOutcome string
+
+const (
+	// ReclaimTerminal means Redis reported that the scan wrapped.
+	ReclaimTerminal ReclaimOutcome = "terminal"
+	// ReclaimNoGroup means the group vanished and invalidated its cursor.
+	ReclaimNoGroup ReclaimOutcome = "nogroup"
+	// ReclaimError means the scan stopped on a transient transport failure.
+	ReclaimError ReclaimOutcome = "error"
+	// ReclaimBudgetExhausted means the scan reached its per-tick page cap.
+	ReclaimBudgetExhausted ReclaimOutcome = "budget_exhausted"
+)
+
+// StreamConsumerConfig contains transport mechanics shared by stream workers.
+// Decode, processing, ACK policy, lifecycle checks, and metric labels remain in
+// the domain adapter supplied through Handle and Observe.
+type StreamConsumerConfig struct {
+	Stream         string
+	Group          string
+	Consumer       string
+	ReadCount      int64
+	ReadBlock      time.Duration
+	ReapInterval   time.Duration
+	MinIdleReap    time.Duration
+	ReapCount      int64
+	ReapPageBudget int
+	ReadBackoffMin time.Duration
+	ReadBackoffMax time.Duration
+}
+
+// StreamConsumerFuncs is the Redis transport seam. The value-returning shape
+// keeps the state machine independent of go-redis command types in tests.
+type StreamConsumerFuncs struct {
+	CreateGroup func(context.Context, string, string, string) error
+	ReadGroup   func(context.Context, *goredis.XReadGroupArgs) ([]goredis.XStream, error)
+	AutoClaim   func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error)
+}
+
+// StreamConsumerObserver lets domain adapters attach their own logs and metric
+// labels without teaching the transport state machine about domain names.
+type StreamConsumerObserver struct {
+	ReadError        func(context.Context, error)
+	RecreateError    func(context.Context, error)
+	ReclaimError     func(context.Context, error)
+	Reclaimed        func(int)
+	ReclaimCompleted func(ReclaimOutcome)
+}
+
+// StreamConsumer centralizes the consume/reclaim state machine used by event,
+// catalog-ingest, and embedder workers.
+type StreamConsumer struct {
+	cfg     StreamConsumerConfig
+	fns     StreamConsumerFuncs
+	handle  func(context.Context, goredis.XMessage)
+	observe StreamConsumerObserver
+}
+
+// NewStreamConsumer builds a consumer with explicit domain callbacks.
+func NewStreamConsumer(
+	cfg StreamConsumerConfig,
+	fns StreamConsumerFuncs,
+	handle func(context.Context, goredis.XMessage),
+	observe StreamConsumerObserver,
+) *StreamConsumer {
+	return &StreamConsumer{cfg: cfg, fns: fns, handle: handle, observe: observe}
+}
+
+// Init creates the configured group and treats BUSYGROUP as success.
+func (c *StreamConsumer) Init(ctx context.Context) error {
+	err := c.fns.CreateGroup(ctx, c.cfg.Stream, c.cfg.Group, "0")
+	if err != nil && !IsBusyGroupError(err) {
+		return err
+	}
+	return nil
+}
+
+// Run consumes new entries and concurrently reclaims abandoned pending
+// entries until ctx ends. All goroutines are joined before it returns.
+func (c *StreamConsumer) Run(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.reapLoop(ctx)
+	}()
+	c.consumeLoop(ctx)
+	wg.Wait()
+}
+
+func (c *StreamConsumer) consumeLoop(ctx context.Context) {
+	backoff := c.cfg.ReadBackoffMin
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		streams, err := c.fns.ReadGroup(ctx, &goredis.XReadGroupArgs{
+			Group: c.cfg.Group, Consumer: c.cfg.Consumer,
+			Streams: []string{c.cfg.Stream, ">"}, Count: c.cfg.ReadCount, Block: c.cfg.ReadBlock,
+		})
+		if errors.Is(err, goredis.Nil) {
+			continue
+		}
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+			if IsNoGroupError(err) {
+				if createErr := c.Init(ctx); createErr != nil && c.observe.RecreateError != nil {
+					c.observe.RecreateError(ctx, createErr)
+				}
+			}
+			if c.observe.ReadError != nil {
+				c.observe.ReadError(ctx, err)
+			}
+			if !sleepContext(ctx, backoff) {
+				return
+			}
+			backoff = min(backoff*2, c.cfg.ReadBackoffMax)
+			continue
+		}
+		backoff = c.cfg.ReadBackoffMin
+
+		for _, stream := range streams {
+			for _, msg := range stream.Messages {
+				c.handle(ctx, msg)
+			}
+		}
+	}
+}
+
+func (c *StreamConsumer) reapLoop(ctx context.Context) {
+	cursor := initialReclaimCursor
+	ticker := time.NewTicker(c.cfg.ReapInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cursor = c.ReapOnce(ctx, cursor)
+		}
+	}
+}
+
+// ReapOnce scans at most ReapPageBudget pages and returns the cursor for the
+// next tick. Empty pages advance; transient failures retain the cursor; a
+// terminal cursor or NOGROUP resets it.
+func (c *StreamConsumer) ReapOnce(ctx context.Context, cursor string) string {
+	if cursor == "" {
+		cursor = initialReclaimCursor
+	}
+	for page := 0; page < c.cfg.ReapPageBudget; page++ {
+		msgs, next, err := c.fns.AutoClaim(ctx, &goredis.XAutoClaimArgs{
+			Stream: c.cfg.Stream, Group: c.cfg.Group, Consumer: c.cfg.Consumer,
+			MinIdle: c.cfg.MinIdleReap, Start: cursor, Count: c.cfg.ReapCount,
+		})
+		if err != nil {
+			if IsNoGroupError(err) {
+				c.completed(ReclaimNoGroup)
+				return initialReclaimCursor
+			}
+			if ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && c.observe.ReclaimError != nil {
+				c.observe.ReclaimError(ctx, err)
+			}
+			c.completed(ReclaimError)
+			return cursor
+		}
+		if len(msgs) > 0 && c.observe.Reclaimed != nil {
+			c.observe.Reclaimed(len(msgs))
+		}
+		for _, msg := range msgs {
+			c.handle(ctx, msg)
+		}
+		cursor = next
+		if next == initialReclaimCursor || next == "" {
+			c.completed(ReclaimTerminal)
+			return initialReclaimCursor
+		}
+	}
+	c.completed(ReclaimBudgetExhausted)
+	return cursor
+}
+
+func (c *StreamConsumer) completed(outcome ReclaimOutcome) {
+	if c.observe.ReclaimCompleted != nil {
+		c.observe.ReclaimCompleted(outcome)
+	}
+}
+
+// IsBusyGroupError reports Redis' idempotent group-create response.
+func IsBusyGroupError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "BUSYGROUP")
+}
+
+// IsNoGroupError reports that a stream consumer group no longer exists.
+func IsNoGroupError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "NOGROUP")
+}
+
+func sleepContext(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}

--- a/internal/infra/redis/stream_consumer_test.go
+++ b/internal/infra/redis/stream_consumer_test.go
@@ -35,19 +35,23 @@ func TestStreamConsumerReapStateMachine(t *testing.T) {
 	t.Run("advances empty pages and resets at terminal", func(t *testing.T) {
 		var starts []string
 		var outcomes []ReclaimOutcome
+		var handled []string
+		reclaimed := 0
 		consumer := testStreamConsumer(func(_ context.Context, args *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
 			starts = append(starts, args.Start)
 			if len(starts) == 1 {
-				return nil, "100-0", nil
+				return []goredis.XMessage{{ID: "1-0"}}, "100-0", nil
 			}
 			return nil, "0-0", nil
 		}, func(outcome ReclaimOutcome) { outcomes = append(outcomes, outcome) })
+		consumer.handle = func(_ context.Context, msg goredis.XMessage) { handled = append(handled, msg.ID) }
+		consumer.observe.Reclaimed = func(count int) { reclaimed += count }
 
 		if got := consumer.ReapOnce(context.Background(), ""); got != "0-0" {
 			t.Fatalf("cursor = %q", got)
 		}
-		if fmt.Sprint(starts) != "[0-0 100-0]" || fmt.Sprint(outcomes) != "[terminal]" {
-			t.Fatalf("starts=%v outcomes=%v", starts, outcomes)
+		if fmt.Sprint(starts) != "[0-0 100-0]" || fmt.Sprint(outcomes) != "[terminal]" || fmt.Sprint(handled) != "[1-0]" || reclaimed != 1 {
+			t.Fatalf("starts=%v outcomes=%v handled=%v reclaimed=%d", starts, outcomes, handled, reclaimed)
 		}
 	})
 
@@ -63,16 +67,23 @@ func TestStreamConsumerReapStateMachine(t *testing.T) {
 	})
 
 	t.Run("retains transient error and resets nogroup", func(t *testing.T) {
-		claimErr := errors.New("redis down")
+		transientErr := errors.New("redis down")
+		claimErr := transientErr
+		var observed []error
+		var outcomes []ReclaimOutcome
 		consumer := testStreamConsumer(func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
 			return nil, "", claimErr
-		}, nil)
+		}, func(outcome ReclaimOutcome) { outcomes = append(outcomes, outcome) })
+		consumer.observe.ReclaimError = func(_ context.Context, err error) { observed = append(observed, err) }
 		if got := consumer.ReapOnce(context.Background(), "700-0"); got != "700-0" {
 			t.Fatalf("transient cursor=%q", got)
 		}
 		claimErr = errors.New("NOGROUP missing")
 		if got := consumer.ReapOnce(context.Background(), "700-0"); got != "0-0" {
 			t.Fatalf("nogroup cursor=%q", got)
+		}
+		if len(observed) != 1 || !errors.Is(observed[0], transientErr) || fmt.Sprint(outcomes) != "[error nogroup]" {
+			t.Fatalf("observed=%v outcomes=%v", observed, outcomes)
 		}
 	})
 }
@@ -105,6 +116,69 @@ func TestStreamConsumerRunRecreatesMissingGroupAndHandlesMessages(t *testing.T) 
 	consumer.Run(ctx)
 	if creates != 1 || fmt.Sprint(handled) != "[1-0]" {
 		t.Fatalf("creates=%d handled=%v", creates, handled)
+	}
+}
+
+func TestStreamConsumerRunObservesReadAndRecreateErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reads := 0
+	recreateErrors := 0
+	readErrors := 0
+	consumer := NewStreamConsumer(StreamConsumerConfig{
+		Stream: "s", Group: "g", Consumer: "c", ReadCount: 1,
+		ReadBlock: time.Millisecond, ReapInterval: time.Hour,
+		ReadBackoffMin: time.Millisecond, ReadBackoffMax: 2 * time.Millisecond,
+	}, StreamConsumerFuncs{
+		CreateGroup: func(context.Context, string, string, string) error { return errors.New("redis down") },
+		ReadGroup: func(context.Context, *goredis.XReadGroupArgs) ([]goredis.XStream, error) {
+			reads++
+			switch reads {
+			case 1:
+				return nil, goredis.Nil
+			case 2:
+				return nil, errors.New("NOGROUP missing")
+			case 3:
+				return nil, errors.New("read failed")
+			default:
+				cancel()
+				return nil, context.Canceled
+			}
+		},
+		AutoClaim: func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
+			return nil, "0-0", nil
+		},
+	}, func(context.Context, goredis.XMessage) {}, StreamConsumerObserver{
+		ReadError:     func(context.Context, error) { readErrors++ },
+		RecreateError: func(context.Context, error) { recreateErrors++ },
+	})
+
+	consumer.Run(ctx)
+	if reads != 4 || readErrors != 2 || recreateErrors != 1 {
+		t.Fatalf("reads=%d read_errors=%d recreate_errors=%d", reads, readErrors, recreateErrors)
+	}
+}
+
+func TestStreamConsumerReapLoopRunsOnTicker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	consumer := NewStreamConsumer(StreamConsumerConfig{
+		Stream: "s", Group: "g", Consumer: "c",
+		ReapInterval: time.Millisecond, ReapCount: 1, ReapPageBudget: 1,
+	}, StreamConsumerFuncs{
+		AutoClaim: func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
+			cancel()
+			return nil, "0-0", nil
+		},
+	}, func(context.Context, goredis.XMessage) {}, StreamConsumerObserver{})
+	go func() {
+		consumer.reapLoop(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reap loop did not stop after its tick")
 	}
 }
 

--- a/internal/infra/redis/stream_consumer_test.go
+++ b/internal/infra/redis/stream_consumer_test.go
@@ -1,0 +1,120 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+func TestStreamConsumerInit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "created"},
+		{name: "already exists", err: errors.New("BUSYGROUP exists")},
+		{name: "failure", err: errors.New("redis down"), want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			consumer := NewStreamConsumer(StreamConsumerConfig{Stream: "s", Group: "g"}, StreamConsumerFuncs{
+				CreateGroup: func(context.Context, string, string, string) error { return tc.err },
+			}, nil, StreamConsumerObserver{})
+			if got := consumer.Init(context.Background()); (got != nil) != tc.want {
+				t.Fatalf("Init() error = %v", got)
+			}
+		})
+	}
+}
+
+func TestStreamConsumerReapStateMachine(t *testing.T) {
+	t.Run("advances empty pages and resets at terminal", func(t *testing.T) {
+		var starts []string
+		var outcomes []ReclaimOutcome
+		consumer := testStreamConsumer(func(_ context.Context, args *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
+			starts = append(starts, args.Start)
+			if len(starts) == 1 {
+				return nil, "100-0", nil
+			}
+			return nil, "0-0", nil
+		}, func(outcome ReclaimOutcome) { outcomes = append(outcomes, outcome) })
+
+		if got := consumer.ReapOnce(context.Background(), ""); got != "0-0" {
+			t.Fatalf("cursor = %q", got)
+		}
+		if fmt.Sprint(starts) != "[0-0 100-0]" || fmt.Sprint(outcomes) != "[terminal]" {
+			t.Fatalf("starts=%v outcomes=%v", starts, outcomes)
+		}
+	})
+
+	t.Run("retains cursor at budget", func(t *testing.T) {
+		calls := 0
+		consumer := testStreamConsumer(func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
+			calls++
+			return nil, fmt.Sprintf("%d-0", calls), nil
+		}, nil)
+		if got := consumer.ReapOnce(context.Background(), "700-0"); got != "3-0" || calls != 3 {
+			t.Fatalf("cursor=%q calls=%d", got, calls)
+		}
+	})
+
+	t.Run("retains transient error and resets nogroup", func(t *testing.T) {
+		claimErr := errors.New("redis down")
+		consumer := testStreamConsumer(func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
+			return nil, "", claimErr
+		}, nil)
+		if got := consumer.ReapOnce(context.Background(), "700-0"); got != "700-0" {
+			t.Fatalf("transient cursor=%q", got)
+		}
+		claimErr = errors.New("NOGROUP missing")
+		if got := consumer.ReapOnce(context.Background(), "700-0"); got != "0-0" {
+			t.Fatalf("nogroup cursor=%q", got)
+		}
+	})
+}
+
+func TestStreamConsumerRunRecreatesMissingGroupAndHandlesMessages(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reads := 0
+	creates := 0
+	var handled []string
+	consumer := NewStreamConsumer(StreamConsumerConfig{
+		Stream: "s", Group: "g", Consumer: "c", ReadCount: 2,
+		ReadBlock: time.Millisecond, ReapInterval: time.Hour,
+		ReadBackoffMin: time.Millisecond, ReadBackoffMax: time.Millisecond,
+	}, StreamConsumerFuncs{
+		CreateGroup: func(context.Context, string, string, string) error { creates++; return nil },
+		ReadGroup: func(context.Context, *goredis.XReadGroupArgs) ([]goredis.XStream, error) {
+			reads++
+			if reads == 1 {
+				return nil, errors.New("NOGROUP missing")
+			}
+			cancel()
+			return []goredis.XStream{{Messages: []goredis.XMessage{{ID: "1-0"}}}}, nil
+		},
+		AutoClaim: func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error) {
+			return nil, "0-0", nil
+		},
+	}, func(_ context.Context, msg goredis.XMessage) { handled = append(handled, msg.ID) }, StreamConsumerObserver{})
+
+	consumer.Run(ctx)
+	if creates != 1 || fmt.Sprint(handled) != "[1-0]" {
+		t.Fatalf("creates=%d handled=%v", creates, handled)
+	}
+}
+
+func testStreamConsumer(
+	autoClaim func(context.Context, *goredis.XAutoClaimArgs) ([]goredis.XMessage, string, error),
+	completed func(ReclaimOutcome),
+) *StreamConsumer {
+	return NewStreamConsumer(StreamConsumerConfig{
+		Stream: "s", Group: "g", Consumer: "c", ReapCount: 10, ReapPageBudget: 3,
+	}, StreamConsumerFuncs{AutoClaim: autoClaim}, func(context.Context, goredis.XMessage) {}, StreamConsumerObserver{
+		ReclaimCompleted: completed,
+	})
+}

--- a/internal/ingest/catalog_worker.go
+++ b/internal/ingest/catalog_worker.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 
 	"github.com/jarviisha/codohue/internal/core/nslifecycle"
 	"github.com/jarviisha/codohue/internal/infra/metrics"
+	infraredis "github.com/jarviisha/codohue/internal/infra/redis"
 	"github.com/jarviisha/codohue/pkg/codohuetypes"
 )
 
@@ -86,8 +86,7 @@ func NewCatalogWorker(redisClient *redis.Client, service catalogIngestor, consum
 
 // Init creates the consumer group if it does not already exist.
 func (w *CatalogWorker) Init(ctx context.Context) error {
-	err := w.createGroupFn(ctx, codohuetypes.CatalogStreamName, catalogConsumerGroup, "0")
-	if err != nil && !isBusyGroupErr(err) {
+	if err := w.streamConsumer().Init(ctx); err != nil {
 		return fmt.Errorf("create catalog consumer group: %w", err)
 	}
 	return nil
@@ -97,109 +96,38 @@ func (w *CatalogWorker) Init(ctx context.Context) error {
 // reap/backoff mechanics as the event worker.
 func (w *CatalogWorker) Run(ctx context.Context) {
 	slog.Info("catalog ingest worker started", "stream", codohuetypes.CatalogStreamName, "consumer", w.consumer)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		w.reapPending(ctx)
-	}()
-	defer func() {
-		wg.Wait()
-		slog.Info("catalog ingest worker stopped")
-	}()
-
-	backoff := readErrBackoffMin
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		streams, err := w.readGroupFn(ctx, &redis.XReadGroupArgs{
-			Group:    catalogConsumerGroup,
-			Consumer: w.consumer,
-			Streams:  []string{codohuetypes.CatalogStreamName, ">"},
-			Count:    10,
-			Block:    5 * time.Second,
-		})
-		if errors.Is(err, redis.Nil) {
-			continue
-		}
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			if isNoGroupErr(err) {
-				if createErr := w.createGroupFn(ctx, codohuetypes.CatalogStreamName, catalogConsumerGroup, "0"); createErr != nil && !isBusyGroupErr(createErr) {
-					slog.Warn("catalog ingest recreate consumer group failed", "error", createErr)
-				}
-			}
-			slog.Warn("catalog ingest xreadgroup failed", "error", err)
-			if !sleepCtx(ctx, backoff) {
-				return
-			}
-			backoff = min(backoff*2, readErrBackoffMax)
-			continue
-		}
-		backoff = readErrBackoffMin
-
-		for _, stream := range streams {
-			for _, msg := range stream.Messages {
-				w.handleMessage(ctx, msg)
-			}
-		}
-	}
-}
-
-func (w *CatalogWorker) reapPending(ctx context.Context) {
-	ticker := time.NewTicker(reapInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		w.reapOnce(ctx)
-	}
+	defer slog.Info("catalog ingest worker stopped")
+	w.streamConsumer().Run(ctx)
 }
 
 func (w *CatalogWorker) reapOnce(ctx context.Context) {
-	if w.reapCursor == "" {
-		w.reapCursor = "0-0"
-	}
-	for page := 0; page < reapPageBudget; page++ {
-		start := w.reapCursor
-		msgs, next, err := w.autoClaimFn(ctx, &redis.XAutoClaimArgs{
-			Stream: codohuetypes.CatalogStreamName, Group: catalogConsumerGroup, Consumer: w.consumer,
-			MinIdle: minIdleReap, Start: start, Count: reapBatchSize,
-		})
-		if err != nil {
-			if isNoGroupErr(err) {
-				w.reapCursor = "0-0"
-			} else if ctx.Err() == nil {
-				slog.Warn("catalog ingest xautoclaim failed", "error", err)
-			}
-			metrics.StreamReclaimCyclesTotal.WithLabelValues("catalog", "", "error").Inc()
-			return
-		}
-		if len(msgs) > 0 {
-			metrics.StreamReclaimedTotal.WithLabelValues("catalog", "").Add(float64(len(msgs)))
-		}
-		for _, msg := range msgs {
-			w.handleMessage(ctx, msg)
-		}
-		w.reapCursor = next
-		if next == "0-0" || next == "" {
-			w.reapCursor = "0-0"
-			metrics.StreamReclaimCyclesTotal.WithLabelValues("catalog", "", "terminal").Inc()
-			return
-		}
-	}
-	metrics.StreamReclaimCyclesTotal.WithLabelValues("catalog", "", "budget_exhausted").Inc()
+	w.reapCursor = w.streamConsumer().ReapOnce(ctx, w.reapCursor)
+}
+
+func (w *CatalogWorker) streamConsumer() *infraredis.StreamConsumer {
+	return infraredis.NewStreamConsumer(infraredis.StreamConsumerConfig{
+		Stream: codohuetypes.CatalogStreamName, Group: catalogConsumerGroup, Consumer: w.consumer,
+		ReadCount: 10, ReadBlock: 5 * time.Second,
+		ReapInterval: reapInterval, MinIdleReap: minIdleReap,
+		ReapCount: reapBatchSize, ReapPageBudget: reapPageBudget,
+		ReadBackoffMin: readErrBackoffMin, ReadBackoffMax: readErrBackoffMax,
+	}, infraredis.StreamConsumerFuncs{
+		CreateGroup: w.createGroupFn,
+		ReadGroup:   w.readGroupFn,
+		AutoClaim:   w.autoClaimFn,
+	}, w.handleMessage, infraredis.StreamConsumerObserver{
+		ReadError: func(_ context.Context, err error) { slog.Warn("catalog ingest xreadgroup failed", "error", err) },
+		RecreateError: func(_ context.Context, err error) {
+			slog.Warn("catalog ingest recreate consumer group failed", "error", err)
+		},
+		ReclaimError: func(_ context.Context, err error) { slog.Warn("catalog ingest xautoclaim failed", "error", err) },
+		Reclaimed: func(count int) {
+			metrics.StreamReclaimedTotal.WithLabelValues("catalog", "").Add(float64(count))
+		},
+		ReclaimCompleted: func(outcome infraredis.ReclaimOutcome) {
+			metrics.StreamReclaimCyclesTotal.WithLabelValues("catalog", "", string(outcome)).Inc()
+		},
+	})
 }
 
 // handleMessage decodes and ingests one stream entry. Permanent rejections

--- a/internal/ingest/worker.go
+++ b/internal/ingest/worker.go
@@ -6,14 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 
 	"github.com/jarviisha/codohue/internal/core/nslifecycle"
 	"github.com/jarviisha/codohue/internal/infra/metrics"
+	infraredis "github.com/jarviisha/codohue/internal/infra/redis"
 )
 
 const (
@@ -94,8 +93,7 @@ func NewWorker(redisClient *redis.Client, service *Service, consumer string) *Wo
 
 // Init creates the consumer group if it does not already exist.
 func (w *Worker) Init(ctx context.Context) error {
-	err := w.createGroupFn(ctx, streamName, consumerGroup, "0")
-	if err != nil && !isBusyGroupErr(err) {
+	if err := w.streamConsumer().Init(ctx); err != nil {
 		return fmt.Errorf("create consumer group: %w", err)
 	}
 	return nil
@@ -108,120 +106,37 @@ func (w *Worker) Init(ctx context.Context) error {
 // when it is permanently unprocessable).
 func (w *Worker) Run(ctx context.Context) {
 	slog.Info("ingest worker started", "stream", streamName, "consumer", w.consumer)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		w.reapPending(ctx)
-	}()
-	defer func() {
-		wg.Wait()
-		slog.Info("ingest worker stopped")
-	}()
-
-	backoff := readErrBackoffMin
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		streams, err := w.readGroupFn(ctx, &redis.XReadGroupArgs{
-			Group:    consumerGroup,
-			Consumer: w.consumer,
-			Streams:  []string{streamName, ">"},
-			Count:    10,
-			Block:    5 * time.Second,
-		})
-		if errors.Is(err, redis.Nil) {
-			continue // no new messages within the block window
-		}
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			if isNoGroupErr(err) {
-				// The stream or group vanished (e.g. Redis restarted without
-				// persistence). Recreate instead of spinning on NOGROUP.
-				if createErr := w.createGroupFn(ctx, streamName, consumerGroup, "0"); createErr != nil && !isBusyGroupErr(createErr) {
-					slog.Warn("ingest recreate consumer group failed", "error", createErr)
-				}
-			}
-			slog.Warn("ingest xreadgroup failed", "error", err)
-			if !sleepCtx(ctx, backoff) {
-				return
-			}
-			backoff = min(backoff*2, readErrBackoffMax)
-			continue
-		}
-		backoff = readErrBackoffMin
-
-		for _, stream := range streams {
-			for _, msg := range stream.Messages {
-				w.handleMessage(ctx, msg)
-			}
-		}
-	}
-}
-
-// reapPending periodically reclaims entries idle in the PEL — left there by a
-// crashed replica or by a processing failure — and re-processes them.
-func (w *Worker) reapPending(ctx context.Context) {
-	ticker := time.NewTicker(reapInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		w.reapOnce(ctx)
-	}
+	defer slog.Info("ingest worker stopped")
+	w.streamConsumer().Run(ctx)
 }
 
 // reapOnce runs a single XAUTOCLAIM pass and re-processes what it claimed.
 func (w *Worker) reapOnce(ctx context.Context) {
-	if w.reapCursor == "" {
-		w.reapCursor = "0-0"
-	}
-	for page := 0; page < reapPageBudget; page++ {
-		start := w.reapCursor
-		msgs, next, err := w.autoClaimFn(ctx, &redis.XAutoClaimArgs{
-			Stream: streamName, Group: consumerGroup, Consumer: w.consumer,
-			MinIdle: minIdleReap, Start: start, Count: reapBatchSize,
-		})
-		if err != nil {
-			if isNoGroupErr(err) {
-				w.reapCursor = "0-0"
-			} else if ctx.Err() == nil {
-				slog.Warn("ingest xautoclaim failed", "error", err)
-			}
-			metrics.StreamReclaimCyclesTotal.WithLabelValues("events", "", "error").Inc()
-			return
-		}
-		// Counted per page rather than per cycle: a cycle says the scan ran, this
-		// says it found work. Without it a PEL draining steadily and a PEL that
-		// is simply empty produce the same cycle counts.
-		if len(msgs) > 0 {
-			metrics.StreamReclaimedTotal.WithLabelValues("events", "").Add(float64(len(msgs)))
-		}
-		for _, msg := range msgs {
-			w.handleMessage(ctx, msg)
-		}
-		w.reapCursor = next
-		if next == "0-0" || next == "" {
-			w.reapCursor = "0-0"
-			metrics.StreamReclaimCyclesTotal.WithLabelValues("events", "", "terminal").Inc()
-			return
-		}
-	}
-	// The cursor survives the tick, so a saturated budget is a paced scan
-	// rather than a stall — but it is the only signal that the PEL is deeper
-	// than one tick can drain.
-	metrics.StreamReclaimCyclesTotal.WithLabelValues("events", "", "budget_exhausted").Inc()
+	w.reapCursor = w.streamConsumer().ReapOnce(ctx, w.reapCursor)
+}
+
+func (w *Worker) streamConsumer() *infraredis.StreamConsumer {
+	return infraredis.NewStreamConsumer(infraredis.StreamConsumerConfig{
+		Stream: streamName, Group: consumerGroup, Consumer: w.consumer,
+		ReadCount: 10, ReadBlock: 5 * time.Second,
+		ReapInterval: reapInterval, MinIdleReap: minIdleReap,
+		ReapCount: reapBatchSize, ReapPageBudget: reapPageBudget,
+		ReadBackoffMin: readErrBackoffMin, ReadBackoffMax: readErrBackoffMax,
+	}, infraredis.StreamConsumerFuncs{
+		CreateGroup: w.createGroupFn,
+		ReadGroup:   w.readGroupFn,
+		AutoClaim:   w.autoClaimFn,
+	}, w.handleMessage, infraredis.StreamConsumerObserver{
+		ReadError:     func(_ context.Context, err error) { slog.Warn("ingest xreadgroup failed", "error", err) },
+		RecreateError: func(_ context.Context, err error) { slog.Warn("ingest recreate consumer group failed", "error", err) },
+		ReclaimError:  func(_ context.Context, err error) { slog.Warn("ingest xautoclaim failed", "error", err) },
+		Reclaimed: func(count int) {
+			metrics.StreamReclaimedTotal.WithLabelValues("events", "").Add(float64(count))
+		},
+		ReclaimCompleted: func(outcome infraredis.ReclaimOutcome) {
+			metrics.StreamReclaimCyclesTotal.WithLabelValues("events", "", string(outcome)).Inc()
+		},
+	})
 }
 
 // handleMessage decodes and processes one stream entry. Permanently
@@ -282,22 +197,4 @@ func decodeEventMessage(msg redis.XMessage) (*EventPayload, error) {
 		return nil, fmt.Errorf("unmarshal payload: %w", err)
 	}
 	return &payload, nil
-}
-
-func isBusyGroupErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "BUSYGROUP")
-}
-
-func isNoGroupErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "NOGROUP")
-}
-
-// sleepCtx sleeps for d or until ctx is done; it reports false when ctx ended.
-func sleepCtx(ctx context.Context, d time.Duration) bool {
-	select {
-	case <-ctx.Done():
-		return false
-	case <-time.After(d):
-		return true
-	}
 }


### PR DESCRIPTION
## Summary

- centralize Redis stream consume, group recovery, backoff, and reclaim loops in `internal/infra/redis`
- preserve event, catalog-ingest, and embedder adapters as owners of decode, lifecycle, ACK, logging, and metric-label policy
- consolidate reclaim cursor fairness, terminal reset, NOGROUP reset, and the ten-page budget into one tested state machine
- run one joined consumer/reaper unit per generation-aware embedder stream

## Validation

- `make lint`
- `make test`
- `make test-race`
- `make test-e2e`

Closes #18
